### PR TITLE
chore: prepare release v0.10.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.10.3] - 2026-06-15
+
+### Changed
+- Updated locked runtime and tooling dependencies, including Starlette 1.3.1, Uvicorn 0.49.0, Pytest 9.1.0, OpenAPI Generator CLI 7.23.0, and Umami Analytics 1.0.0 (#227, #228, #229, #230, #231).
+
 ## [v0.10.2] - 2026-06-08
 
 ### Changed
@@ -241,7 +246,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release
 
-[Unreleased]: https://github.com/ivanostanin/lucius-mcp/compare/v0.10.2...HEAD
+[Unreleased]: https://github.com/ivanostanin/lucius-mcp/compare/v0.10.3...HEAD
+[v0.10.3]: https://github.com/ivanostanin/lucius-mcp/compare/v0.10.2...v0.10.3
 [v0.10.2]: https://github.com/ivanostanin/lucius-mcp/compare/v0.10.1...v0.10.2
 [v0.10.1]: https://github.com/ivanostanin/lucius-mcp/compare/v0.10.0...v0.10.1
 [v0.10.0]: https://github.com/ivanostanin/lucius-mcp/compare/v0.9.2...v0.10.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lucius-mcp"
-version = "0.10.2"
+version = "0.10.3"
 description = "Allure TestOps MCP Server"
 readme = "README.md"
 license = "Apache-2.0"

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/ivanostanin/lucius-mcp",
     "source": "github"
   },
-  "version": "0.10.2",
+  "version": "0.10.3",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "lucius-mcp",
-      "version": "0.10.2",
+      "version": "0.10.3",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"
@@ -43,7 +43,7 @@
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/ivanostanin/lucius-mcp:0.10.2",
+      "identifier": "ghcr.io/ivanostanin/lucius-mcp:0.10.3",
       "transport": {
         "type": "stdio"
       },
@@ -73,16 +73,16 @@
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/ivanostanin/lucius-mcp/releases/download/v0.10.2/lucius-mcp-0.10.2-uv.mcpb",
-      "fileSha256": "7520f25374831fd0fa25201d4273c6e6d4d9956b032dfc3763da4e4390a95a56",
+      "identifier": "https://github.com/ivanostanin/lucius-mcp/releases/download/v0.10.3/lucius-mcp-0.10.3-uv.mcpb",
+      "fileSha256": "10454ed656c3ffe4aa9c051c9cb2bc897829b3d136a2ed242c2d45f5be4beacb",
       "transport": {
         "type": "stdio"
       }
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/ivanostanin/lucius-mcp/releases/download/v0.10.2/lucius-mcp-0.10.2-python.mcpb",
-      "fileSha256": "a16f0cd3915491036f1819b6cc3f19e1358db37e51e281ccfc91eab30c7fcd31",
+      "identifier": "https://github.com/ivanostanin/lucius-mcp/releases/download/v0.10.3/lucius-mcp-0.10.3-python.mcpb",
+      "fileSha256": "f8f1cd3c1fb3a10c58291440ad4d53ee37fcff1fb65584f4b6085cb8219fbcdb",
       "transport": {
         "type": "stdio"
       }

--- a/uv.lock
+++ b/uv.lock
@@ -903,7 +903,7 @@ wheels = [
 
 [[package]]
 name = "lucius-mcp"
-version = "0.10.2"
+version = "0.10.3"
 source = { editable = "." }
 dependencies = [
     { name = "authlib" },


### PR DESCRIPTION
Prepare release v0.10.3.

Validation run:
- uv run --extra dev ruff format scripts src tests deployment
- uv run --extra dev ruff check scripts src tests deployment --fix --unsafe-fixes
- uv run --extra dev mypy src
- uv run --extra dev pytest tests/unit tests/integration --cov=src --cov-report=term-missing -v
- uv run --extra dev pytest tests/docs
- uv run --extra dev --env-file .env.test pytest tests/e2e -n auto -rs
- skipped: uv run --extra dev pytest tests/packaging