### PR TITLE
chore: prepare release v0.10.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.10.4] - 2026-06-20
+
+### Changed
+- Updated locked runtime dependencies, including `cryptography` 49.0.0, `pydantic-settings` 2.14.2, and `PyJWT` 2.13.0 (#235, #236, #237).
+
 ## [v0.10.3] - 2026-06-15
 
 ### Changed
@@ -246,7 +251,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release
 
-[Unreleased]: https://github.com/ivanostanin/lucius-mcp/compare/v0.10.3...HEAD
+[Unreleased]: https://github.com/ivanostanin/lucius-mcp/compare/v0.10.4...HEAD
+[v0.10.4]: https://github.com/ivanostanin/lucius-mcp/compare/v0.10.3...v0.10.4
 [v0.10.3]: https://github.com/ivanostanin/lucius-mcp/compare/v0.10.2...v0.10.3
 [v0.10.2]: https://github.com/ivanostanin/lucius-mcp/compare/v0.10.1...v0.10.2
 [v0.10.1]: https://github.com/ivanostanin/lucius-mcp/compare/v0.10.0...v0.10.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lucius-mcp"
-version = "0.10.3"
+version = "0.10.4"
 description = "Allure TestOps MCP Server"
 readme = "README.md"
 license = "Apache-2.0"

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/ivanostanin/lucius-mcp",
     "source": "github"
   },
-  "version": "0.10.3",
+  "version": "0.10.4",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "lucius-mcp",
-      "version": "0.10.3",
+      "version": "0.10.4",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"
@@ -43,7 +43,7 @@
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/ivanostanin/lucius-mcp:0.10.3",
+      "identifier": "ghcr.io/ivanostanin/lucius-mcp:0.10.4",
       "transport": {
         "type": "stdio"
       },
@@ -73,16 +73,16 @@
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/ivanostanin/lucius-mcp/releases/download/v0.10.3/lucius-mcp-0.10.3-uv.mcpb",
-      "fileSha256": "10454ed656c3ffe4aa9c051c9cb2bc897829b3d136a2ed242c2d45f5be4beacb",
+      "identifier": "https://github.com/ivanostanin/lucius-mcp/releases/download/v0.10.4/lucius-mcp-0.10.4-uv.mcpb",
+      "fileSha256": "6b0db9705f8999355608458c62fa10b7f744d899b3b7c03369ab58b63a3b0cc5",
       "transport": {
         "type": "stdio"
       }
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/ivanostanin/lucius-mcp/releases/download/v0.10.3/lucius-mcp-0.10.3-python.mcpb",
-      "fileSha256": "f8f1cd3c1fb3a10c58291440ad4d53ee37fcff1fb65584f4b6085cb8219fbcdb",
+      "identifier": "https://github.com/ivanostanin/lucius-mcp/releases/download/v0.10.4/lucius-mcp-0.10.4-python.mcpb",
+      "fileSha256": "90f8aac216e83ec5c193e7976ae7e2ca468009cce46eff66dca13a6481240fc8",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
Prepare release v0.10.4.

## What changed
- bump project version to 0.10.4
- publish v0.10.4 changelog notes for dependency updates #235, #236, and #237
- refresh MCP registry metadata and MCP bundle hashes in server.json

## Validation
- uv run --python 3.13 --extra dev ruff check .
- uv run --python 3.13 --extra dev mypy src
- uv run --python 3.13 --extra dev pytest tests/unit tests/integration
- uv run --python 3.13 --extra dev pytest tests/docs
- uv run --env-file .env.test pytest tests/e2e -n auto
- skipped packaging tests per request