### PR TITLE
chore: prepare release v0.10.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.10.5] - 2026-06-20
+
+### Changed
+- Pinned non-Windows `cryptography` builds to `48.0.1` to avoid the OpenSSL scan failure while preserving the Windows ARM64 wheel pin (`46.0.3`) (#239).
+
 ## [v0.10.4] - 2026-06-20
 
 ### Changed
@@ -251,7 +256,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release
 
-[Unreleased]: https://github.com/ivanostanin/lucius-mcp/compare/v0.10.4...HEAD
+[Unreleased]: https://github.com/ivanostanin/lucius-mcp/compare/v0.10.5...HEAD
+[v0.10.5]: https://github.com/ivanostanin/lucius-mcp/compare/v0.10.4...v0.10.5
 [v0.10.4]: https://github.com/ivanostanin/lucius-mcp/compare/v0.10.3...v0.10.4
 [v0.10.3]: https://github.com/ivanostanin/lucius-mcp/compare/v0.10.2...v0.10.3
 [v0.10.2]: https://github.com/ivanostanin/lucius-mcp/compare/v0.10.1...v0.10.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lucius-mcp"
-version = "0.10.4"
+version = "0.10.5"
 description = "Allure TestOps MCP Server"
 readme = "README.md"
 license = "Apache-2.0"

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/ivanostanin/lucius-mcp",
     "source": "github"
   },
-  "version": "0.10.4",
+  "version": "0.10.5",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "lucius-mcp",
-      "version": "0.10.4",
+      "version": "0.10.5",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"
@@ -43,7 +43,7 @@
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/ivanostanin/lucius-mcp:0.10.4",
+      "identifier": "ghcr.io/ivanostanin/lucius-mcp:0.10.5",
       "transport": {
         "type": "stdio"
       },
@@ -73,16 +73,16 @@
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/ivanostanin/lucius-mcp/releases/download/v0.10.4/lucius-mcp-0.10.4-uv.mcpb",
-      "fileSha256": "6b0db9705f8999355608458c62fa10b7f744d899b3b7c03369ab58b63a3b0cc5",
+      "identifier": "https://github.com/ivanostanin/lucius-mcp/releases/download/v0.10.5/lucius-mcp-0.10.5-uv.mcpb",
+      "fileSha256": "587ea987d8a76b53352b1aab03f3bdd461fe48cb69bc536efa0d93a555a98d45",
       "transport": {
         "type": "stdio"
       }
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/ivanostanin/lucius-mcp/releases/download/v0.10.4/lucius-mcp-0.10.4-python.mcpb",
-      "fileSha256": "90f8aac216e83ec5c193e7976ae7e2ca468009cce46eff66dca13a6481240fc8",
+      "identifier": "https://github.com/ivanostanin/lucius-mcp/releases/download/v0.10.5/lucius-mcp-0.10.5-python.mcpb",
+      "fileSha256": "5e72236f163ff82d330f2b44c1454b274c92b981a0a732d3d679e1ac0ebd189f",
       "transport": {
         "type": "stdio"
       }

--- a/uv.lock
+++ b/uv.lock
@@ -903,7 +903,7 @@ wheels = [
 
 [[package]]
 name = "lucius-mcp"
-version = "0.10.4"
+version = "0.10.5"
 source = { editable = "." }
 dependencies = [
     { name = "authlib" },


### PR DESCRIPTION
Prepare release v0.10.5.

## What changed
- bump project version to 0.10.5
- publish v0.10.5 changelog notes for the cryptography pin in #239
- refresh MCP registry metadata and MCP bundle hashes in server.json
- update the lockfile metadata to reference lucius-mcp 0.10.5

## Validation
- uv run --python 3.13 --extra dev ruff check .
- uv run --python 3.13 --extra dev mypy src
- uv run --python 3.13 --extra dev pytest tests/unit tests/integration
- uv run --python 3.13 --extra dev pytest tests/docs
- uv run --env-file .env.test pytest tests/e2e -n auto
- skipped packaging tests per request