### PR TITLE
chore: prepare release v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.11.0] - 2026-07-06
+
+### Added
+- Added launch manual execution tools for listing results, scheduling manual reruns, starting manual sessions, submitting manual results, and uploading evidence to manual results and steps (#263).
+
+### Changed
+- Updated locked runtime and tooling dependencies, including `joserfc` 1.6.8 and `ruff` 0.15.20 (#252, #254, #264, #265).
+
 ## [v0.10.6] - 2026-06-22
 
 ### Changed
@@ -261,7 +269,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release
 
-[Unreleased]: https://github.com/ivanostanin/lucius-mcp/compare/v0.10.6...HEAD
+[Unreleased]: https://github.com/ivanostanin/lucius-mcp/compare/v0.11.0...HEAD
+[v0.11.0]: https://github.com/ivanostanin/lucius-mcp/compare/v0.10.6...v0.11.0
 [v0.10.6]: https://github.com/ivanostanin/lucius-mcp/compare/v0.10.5...v0.10.6
 [v0.10.5]: https://github.com/ivanostanin/lucius-mcp/compare/v0.10.4...v0.10.5
 [v0.10.4]: https://github.com/ivanostanin/lucius-mcp/compare/v0.10.3...v0.10.4

--- a/docs/mcp_manifest.json
+++ b/docs/mcp_manifest.json
@@ -6,7 +6,7 @@
   "serverInfo": {
     "name": "lucius-mcp",
     "title": null,
-    "version": "0.10.6",
+    "version": "0.11.0",
     "websiteUrl": null,
     "icons": null
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lucius-mcp"
-version = "0.10.6"
+version = "0.11.0"
 description = "Allure TestOps MCP Server"
 readme = "README.md"
 license = "Apache-2.0"

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/ivanostanin/lucius-mcp",
     "source": "github"
   },
-  "version": "0.10.6",
+  "version": "0.11.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "lucius-mcp",
-      "version": "0.10.6",
+      "version": "0.11.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"
@@ -43,7 +43,7 @@
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/ivanostanin/lucius-mcp:0.10.6",
+      "identifier": "ghcr.io/ivanostanin/lucius-mcp:0.11.0",
       "transport": {
         "type": "stdio"
       },
@@ -73,16 +73,16 @@
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/ivanostanin/lucius-mcp/releases/download/v0.10.6/lucius-mcp-0.10.6-uv.mcpb",
-      "fileSha256": "f95a00ba12706ea0523aeb8a32642a343f6a7154c5957d19e2b3f7d41425f0fd",
+      "identifier": "https://github.com/ivanostanin/lucius-mcp/releases/download/v0.11.0/lucius-mcp-0.11.0-uv.mcpb",
+      "fileSha256": "c9d22c6bd6c94a32fefbf089858d426e89c17c3d0f1366f8694f0406cc482d0b",
       "transport": {
         "type": "stdio"
       }
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/ivanostanin/lucius-mcp/releases/download/v0.10.6/lucius-mcp-0.10.6-python.mcpb",
-      "fileSha256": "0fed720abc764ab1b9d8949ef4fcd2e751fe465340eccfc107fbf1e834b74c5d",
+      "identifier": "https://github.com/ivanostanin/lucius-mcp/releases/download/v0.11.0/lucius-mcp-0.11.0-python.mcpb",
+      "fileSha256": "c7a243f94f8c094da408bc0fe03b64de1b06c97cb8cb2e2d06adafd352d118f7",
       "transport": {
         "type": "stdio"
       }

--- a/uv.lock
+++ b/uv.lock
@@ -366,7 +366,7 @@ resolution-markers = [
     "(python_full_version < '3.15' and platform_machine == 'ARM64' and sys_platform == 'win32') or (python_full_version < '3.15' and platform_machine == 'aarch64' and sys_platform == 'win32')",
 ]
 dependencies = [
-    { name = "cffi", marker = "(platform_machine == 'ARM64' and platform_python_implementation != 'PyPy' and sys_platform == 'win32') or (platform_machine == 'aarch64' and platform_python_implementation != 'PyPy' and sys_platform == 'win32')" },
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9f/33/c00162f49c0e2fe8064a62cb92b93e50c74a72bc370ab92f86112b33ff62/cryptography-46.0.3.tar.gz", hash = "sha256:a8b17438104fed022ce745b362294d9ce35b4c2e45c1d958ad4a4b019285f4a1", size = 749258, upload-time = "2025-10-15T23:18:31.74Z" }
 wheels = [
@@ -384,7 +384,7 @@ resolution-markers = [
     "(python_full_version < '3.15' and platform_machine != 'ARM64' and platform_machine != 'aarch64') or (python_full_version < '3.15' and sys_platform != 'win32')",
 ]
 dependencies = [
-    { name = "cffi", marker = "(platform_machine != 'ARM64' and platform_machine != 'aarch64' and platform_python_implementation != 'PyPy') or (platform_python_implementation != 'PyPy' and sys_platform != 'win32')" },
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/12/45/870e7f4bef50e5f53b9f51d4428aee5290eedf58ba443f16b1ebb7ab8e66/cryptography-48.0.1.tar.gz", hash = "sha256:266f4ee051abb2f725b74ef8072b521ce1feacf685a3364fa6a6b45548db791a", size = 832989, upload-time = "2026-06-09T22:32:31.8Z" }
 wheels = [
@@ -903,7 +903,7 @@ wheels = [
 
 [[package]]
 name = "lucius-mcp"
-version = "0.10.6"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "authlib" },
@@ -1762,8 +1762,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", version = "48.0.1", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'ARM64' and platform_machine != 'aarch64') or sys_platform != 'win32'" },
-    { name = "jeepney", marker = "(platform_machine != 'ARM64' and platform_machine != 'aarch64') or sys_platform != 'win32'" },
+    { name = "cryptography", version = "48.0.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "jeepney" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
Prepare release v0.11.0.

## What changed
- Added the manual launch execution workflow for listing results, scheduling reruns, starting manual sessions, submitting manual results, and uploading evidence (#263).
- Bumped the project version to `0.11.0` and refreshed changelog, manifests, lockfile, and MCP registry metadata.

## Validation
- `./scripts/full-test-suite.sh`
- `UV_CACHE_DIR=/private/tmp/lucius-uv-cache uv run pytest tests/docs`

## Release artifacts
- Built `lucius-mcp-0.11.0-uv.mcpb` and `lucius-mcp-0.11.0-python.mcpb` locally and updated `server.json` hashes from those artifacts.