### PR TITLE
chore: prepare release v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.12.0] - 2026-07-15
+
+### Added
+- Added `upload_test_results` to append externally produced test results to an existing launch with concurrent batch processing and per-result failure reporting (#271).
+- Added `unlink_issue_from_test_case` for idempotent issue-link removal from test cases by issue key or internal link ID (#272).
+
+### Changed
+- Updated locked runtime and tooling dependencies, including FastMCP 3.4.4, Cyclopts 4.21.0, Mypy 2.2.0, Ruff 0.15.21, and Uvicorn 0.51.0 (#278).
+
 ## [v0.11.0] - 2026-07-06
 
 ### Added
@@ -269,7 +278,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release
 
-[Unreleased]: https://github.com/ivanostanin/lucius-mcp/compare/v0.11.0...HEAD
+[Unreleased]: https://github.com/ivanostanin/lucius-mcp/compare/v0.12.0...HEAD
+[v0.12.0]: https://github.com/ivanostanin/lucius-mcp/compare/v0.11.0...v0.12.0
 [v0.11.0]: https://github.com/ivanostanin/lucius-mcp/compare/v0.10.6...v0.11.0
 [v0.10.6]: https://github.com/ivanostanin/lucius-mcp/compare/v0.10.5...v0.10.6
 [v0.10.5]: https://github.com/ivanostanin/lucius-mcp/compare/v0.10.4...v0.10.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lucius-mcp"
-version = "0.11.0"
+version = "0.12.0"
 description = "Allure TestOps MCP Server"
 readme = "README.md"
 license = "Apache-2.0"

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/ivanostanin/lucius-mcp",
     "source": "github"
   },
-  "version": "0.11.0",
+  "version": "0.12.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "lucius-mcp",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"
@@ -43,7 +43,7 @@
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/ivanostanin/lucius-mcp:0.11.0",
+      "identifier": "ghcr.io/ivanostanin/lucius-mcp:0.12.0",
       "transport": {
         "type": "stdio"
       },
@@ -73,16 +73,16 @@
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/ivanostanin/lucius-mcp/releases/download/v0.11.0/lucius-mcp-0.11.0-uv.mcpb",
-      "fileSha256": "c9d22c6bd6c94a32fefbf089858d426e89c17c3d0f1366f8694f0406cc482d0b",
+      "identifier": "https://github.com/ivanostanin/lucius-mcp/releases/download/v0.12.0/lucius-mcp-0.12.0-uv.mcpb",
+      "fileSha256": "d04396067c8f6f8575caf10d2898e69e48e0ada2084517f78813498fdc81655f",
       "transport": {
         "type": "stdio"
       }
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/ivanostanin/lucius-mcp/releases/download/v0.11.0/lucius-mcp-0.11.0-python.mcpb",
-      "fileSha256": "c7a243f94f8c094da408bc0fe03b64de1b06c97cb8cb2e2d06adafd352d118f7",
+      "identifier": "https://github.com/ivanostanin/lucius-mcp/releases/download/v0.12.0/lucius-mcp-0.12.0-python.mcpb",
+      "fileSha256": "e5f44f9ec405786eea84d961612e6673164fba8be3c8d13f2e16f8335bc70caf",
       "transport": {
         "type": "stdio"
       }

--- a/uv.lock
+++ b/uv.lock
@@ -369,7 +369,7 @@ resolution-markers = [
     "(python_full_version < '3.15' and platform_machine == 'ARM64' and sys_platform == 'win32') or (python_full_version < '3.15' and platform_machine == 'aarch64' and sys_platform == 'win32')",
 ]
 dependencies = [
-    { name = "cffi", marker = "(platform_machine == 'ARM64' and platform_python_implementation != 'PyPy' and sys_platform == 'win32') or (platform_machine == 'aarch64' and platform_python_implementation != 'PyPy' and sys_platform == 'win32')" },
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9f/33/c00162f49c0e2fe8064a62cb92b93e50c74a72bc370ab92f86112b33ff62/cryptography-46.0.3.tar.gz", hash = "sha256:a8b17438104fed022ce745b362294d9ce35b4c2e45c1d958ad4a4b019285f4a1", size = 749258, upload-time = "2025-10-15T23:18:31.74Z" }
 wheels = [
@@ -387,7 +387,7 @@ resolution-markers = [
     "(python_full_version < '3.15' and platform_machine != 'ARM64' and platform_machine != 'aarch64') or (python_full_version < '3.15' and sys_platform != 'win32')",
 ]
 dependencies = [
-    { name = "cffi", marker = "(platform_machine != 'ARM64' and platform_machine != 'aarch64' and platform_python_implementation != 'PyPy') or (platform_python_implementation != 'PyPy' and sys_platform != 'win32')" },
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/12/45/870e7f4bef50e5f53b9f51d4428aee5290eedf58ba443f16b1ebb7ab8e66/cryptography-48.0.1.tar.gz", hash = "sha256:266f4ee051abb2f725b74ef8072b521ce1feacf685a3364fa6a6b45548db791a", size = 832989, upload-time = "2026-06-09T22:32:31.8Z" }
 wheels = [
@@ -908,7 +908,7 @@ wheels = [
 
 [[package]]
 name = "lucius-mcp"
-version = "0.11.0"
+version = "0.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "authlib" },
@@ -1768,8 +1768,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", version = "48.0.1", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'ARM64' and platform_machine != 'aarch64') or sys_platform != 'win32'" },
-    { name = "jeepney", marker = "(platform_machine != 'ARM64' and platform_machine != 'aarch64') or sys_platform != 'win32'" },
+    { name = "cryptography", version = "48.0.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "jeepney" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
Prepare release v0.12.0.

## Highlights

- Add `upload_test_results` for concurrent external result uploads with per-result failure reporting.
- Add idempotent `unlink_issue_from_test_case` support.

## Validation

- Non-packaging QA passed: 929 unit/integration tests, 19 docs tests, and 224 E2E tests passed (1 environment-based skip).
- Packaging tests were intentionally skipped per request.
