### PR TITLE
chore(release): sync MCP manifest workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,10 @@ uv run mypy src
 - When touching telemetry, preserve the privacy constraints documented in `docs/development.md`.
 - When updating stories or sprint artifacts, keep them consistent with the code and tests.
 
+## Pull Request Defaults
+
+- When creating a pull request, use a Conventional Commit title and complete the repository's existing pull-request template unless the user instructs otherwise.
+
 ## Validation
 
 - Run the smallest relevant checks first.

--- a/docs/mcp_manifest.json
+++ b/docs/mcp_manifest.json
@@ -1,12 +1,12 @@
 {
   "environment": {
-    "fastmcp": "3.4.3",
-    "mcp": "1.26.0"
+    "fastmcp": "3.4.4",
+    "mcp": "1.28.1"
   },
   "serverInfo": {
     "name": "lucius-mcp",
     "title": null,
-    "version": "0.11.0",
+    "version": "0.12.0",
     "websiteUrl": null,
     "icons": null
   },

--- a/scripts/prepare-release.md
+++ b/scripts/prepare-release.md
@@ -31,23 +31,30 @@ uv run pre-commit install --install-hooks --hook-type pre-commit --hook-type pre
 uv sync --all-extras
 ```
 
-### 3. Changelog Update
+### 3. Regenerate MCP Documentation Manifest
+- Regenerate `docs/mcp_manifest.json` after the version bump and dependency sync so the published MCP Registry documentation reflects the release version and current tool metadata.
+```bash
+uv run --locked fastmcp inspect src/main.py --format mcp -o docs/mcp_manifest.json
+uv run --locked pytest tests/docs/test_mcp_manifest.py -q
+```
+
+### 4. Changelog Update
 - Update `CHANGELOG.md` following the [Changelog Update Protocol](update-changelog.md).
 - Ensure all major changes, fixes, and additions are categorized correctly.
 
-### 4. Build MCPB Bundles Locally
+### 5. Build MCPB Bundles Locally
 - Build local MCPB artifacts for the release version.
 ```bash
 ./deployment/scripts/build-mcpb.sh
 ```
 
-### 5. Update MCP Registry Metadata in `server.json`
+### 6. Update MCP Registry Metadata in `server.json`
 - Update release version metadata and `fileSha256` values for all MCPB packages in `server.json` from the local `dist/*.mcpb` artifacts.
 ```bash
 uv run python deployment/scripts/update_mcp_registry_metadata.py
 ```
 
-### 6. Commit and Pull Request
+### 7. Commit and Pull Request
 - Commit changes with a descriptive message (e.g., `chore: prepare release v0.x.x`).
 - Push to the release branch.
 - Create a PR to `main` with `gh` CLI. The PR title MUST use Conventional Commit format (e.g., `chore: prepare release v0.x.x`).
@@ -60,7 +67,7 @@ gh pr create \
 ```
 - Wait for CI/CD checks to pass on the PR.
 
-### 7. Tagging (Manual/Triggered)
+### 8. Tagging (Manual/Triggered)
 - Once the PR is merged to `main`, a git tag MUST be created for the new version.
 - Tag name must match the version (e.g., `v0.x.x`).
 - Push the tag to trigger deployment workflows.

--- a/specs/implementation-artifacts/spec-sync-mcp-manifest-release.md
+++ b/specs/implementation-artifacts/spec-sync-mcp-manifest-release.md
@@ -1,0 +1,33 @@
+---
+title: 'Sync MCP manifest during release'
+type: 'chore'
+created: '2026-07-17'
+status: 'done'
+route: 'one-shot'
+baseline_commit: 'bf78a09cdc519f6842588192b740b33409e49060'
+---
+
+# Sync MCP manifest during release
+
+## Intent
+
+**Problem:** Release version bumps can leave the published MCP documentation manifest stale because the existing hook only runs for staged tool changes.
+
+**Approach:** Make manifest regeneration an explicit, locked release step, refresh the current generated artifact, and verify its version against package metadata.
+
+## Suggested Review Order
+
+**Release workflow**
+
+- Regenerate and verify published MCP metadata after release dependency synchronization.
+  [`prepare-release.md:34`](../../scripts/prepare-release.md#L34)
+
+**Regression protection**
+
+- Compare manifest server version directly with the project release version.
+  [`test_mcp_manifest.py:153`](../../tests/docs/test_mcp_manifest.py#L153)
+
+**Generated release metadata**
+
+- Confirm the checked-in manifest reflects the current dependency and server versions.
+  [`mcp_manifest.json:1`](../../docs/mcp_manifest.json#L1)

--- a/tests/docs/test_mcp_manifest.py
+++ b/tests/docs/test_mcp_manifest.py
@@ -1,4 +1,5 @@
 import json
+import tomllib
 from pathlib import Path
 
 import pytest
@@ -18,6 +19,19 @@ def _load_manifest() -> dict[str, object]:
     raw = json.loads(manifest_path.read_text(encoding="utf-8"))
     assert isinstance(raw, dict), "docs/mcp_manifest.json must be a JSON object"
     return raw
+
+
+def _project_version() -> str:
+    pyproject_path = _project_root() / "pyproject.toml"
+    with pyproject_path.open("rb") as pyproject_file:
+        pyproject = tomllib.load(pyproject_file)
+
+    project = pyproject.get("project")
+    assert isinstance(project, dict), "pyproject.toml must contain a project table"
+
+    version = project.get("version")
+    assert isinstance(version, str) and version.strip(), "pyproject.toml project.version must be a non-empty string"
+    return version
 
 
 def _manifest_tools(manifest: dict[str, object]) -> list[dict[str, object]]:
@@ -134,6 +148,13 @@ def test_manifest_lists_all_registered_tools() -> None:
 
     if errors:
         pytest.fail("Tool coverage mismatch:\n- " + "\n- ".join(errors))
+
+
+def test_manifest_version_matches_project_version() -> None:
+    manifest = _load_manifest()
+    server_info = manifest.get("serverInfo")
+    assert isinstance(server_info, dict), "manifest.serverInfo must be an object"
+    assert server_info.get("version") == _project_version()
 
 
 def test_manifest_tools_have_title_description_annotations_and_tags() -> None:


### PR DESCRIPTION
## Description

Adds a locked release step that regenerates `docs/mcp_manifest.json` after the version bump and dependency sync. Refreshes the committed manifest and verifies that its server version matches `pyproject.toml`, preventing stale release documentation.

## Type of Change

- [ ] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] 🧹 Refactoring
- [x] 📝 Documentation
- [x] 🚀 Release/Deployment
- [x] 🧪 Testing update
- [ ] 🔧 Infrastructure/Configuration

## Related Issues/Stories

N/A

## How Has This Been Tested?

- `uv run --locked fastmcp inspect src/main.py --format mcp -o docs/mcp_manifest.json`
- `uv run --locked pytest tests/docs/test_mcp_manifest.py -q`
- `uv run --locked ruff format --check tests/docs/test_mcp_manifest.py`
- `uv run --locked ruff check tests/docs/test_mcp_manifest.py`
- Commit and push hooks: ruff format/check, mypy, and the configured docs/package test suite.

## Checklist

- [ ] PR is human-reviewed.
- [x] Documentation has been updated (if applicable).
- [x] Tests have been added or updated to cover changes.