### PR TITLE
fix(tools): correct launch deletion semantics

### DIFF
--- a/deployment/mcpb/manifest.python.json
+++ b/deployment/mcpb/manifest.python.json
@@ -208,7 +208,7 @@
     },
     {
       "name": "delete_launch",
-      "description": "Delete/archive a launch by ID."
+      "description": "Delete a launch by ID."
     },
     {
       "name": "close_launch",

--- a/deployment/mcpb/manifest.uv.json
+++ b/deployment/mcpb/manifest.uv.json
@@ -207,7 +207,7 @@
     },
     {
       "name": "delete_launch",
-      "description": "Delete/archive a launch by ID."
+      "description": "Delete a launch by ID."
     },
     {
       "name": "close_launch",

--- a/docs/mcp_manifest.json
+++ b/docs/mcp_manifest.json
@@ -2546,12 +2546,12 @@
     {
       "name": "delete_launch",
       "title": "Delete Launch",
-      "description": "Delete/archive a launch by ID.\n⚠️ CAUTION: Destructive.",
+      "description": "Delete a launch by ID.\n⚠️ CAUTION: Destructive.",
       "inputSchema": {
         "additionalProperties": false,
         "properties": {
           "launch_id": {
-            "description": "Launch ID to delete/archive (required).",
+            "description": "Launch ID to delete (required).",
             "type": "integer"
           },
           "project_id": {

--- a/specs/implementation-artifacts/spec-fix-launch-deletion-semantics.md
+++ b/specs/implementation-artifacts/spec-fix-launch-deletion-semantics.md
@@ -1,0 +1,85 @@
+---
+title: 'Fix launch deletion semantics'
+type: 'bugfix'
+created: '2026-07-17'
+status: 'done'
+baseline_commit: 'bf78a09cdc519f6842588192b740b33409e49060'
+context:
+  - '{project-root}/docs/development.md'
+  - '{project-root}/specs/project-context.md'
+---
+
+<frozen-after-approval reason="human-owned intent — do not modify unless human renegotiates">
+
+## Intent
+
+**Problem:** `delete_launch` reports that launches are archived and probes a launch before each deletion. TestOps has no archived-launch state: a second direct DELETE succeeds, while a GET for the deleted ID returns HTTP 500. The preflight GET therefore breaks idempotent deletion and the tool gives users inaccurate terminology.
+
+**Approach:** Make the service delegate deletion directly to the TestOps DELETE endpoint, using only the endpoint response to determine its outcome. Report successful deletion using “deleted” terminology throughout the tool and shipped metadata, while preserving a clear already-deleted outcome when the endpoint explicitly returns 404.
+
+## Boundaries & Constraints
+
+**Always:** Keep tools thin and place deletion behavior in `LaunchService`; retain validation for project and launch IDs; use typed client exceptions; regenerate metadata derived from the tool signature/docstring; add focused unit, integration, and live-E2E coverage; update the manual agentic protocol so it never GETs a just-deleted launch.
+
+**Ask First:** Expanding the correction to delete/archive semantics for entities other than launches, including historical test-case terminology or unrelated planning artifacts.
+
+**Never:** Reintroduce a GET preflight to distinguish launch deletion states; label a launch as archived; infer an already-deleted state from an upstream 5xx; change the deferred authentication-response work in this PR.
+
+## I/O & Edge-Case Matrix
+
+| Scenario | Input / State | Expected Output / Behavior | Error Handling |
+|----------|---------------|----------------------------|----------------|
+| Delete existing launch | Valid launch ID; DELETE returns 204 | Service returns `deleted`; tool says `Deleted Launch <id>` without a launch name | N/A |
+| Repeat deletion | Same ID; DELETE remains idempotent and returns 204 | Service and tool return the same `deleted` completion state; no GET is issued | N/A |
+| Explicit absence | DELETE returns 404 | Service returns `already_deleted`; tool says the launch was already deleted or does not exist | No exception |
+| Server failure | DELETE returns non-404 API error | Propagate the typed API error | Do not claim deletion succeeded |
+
+</frozen-after-approval>
+
+## Code Map
+
+- `src/services/launch_service.py` -- owns launch deletion state and typed error handling.
+- `src/tools/launches.py` -- exposes the MCP deletion tool and plain/JSON wording.
+- `tests/unit/test_launch_service.py` -- service behavior and no-preflight contract.
+- `tests/unit/test_launch_tools.py` and `tests/integration/test_launch_tools.py` -- rendered tool output contract.
+- `tests/e2e/test_launches.py` -- TestOps lifecycle regression coverage.
+- `tests/e2e/helpers/cleanup.py` -- teardown helper that must not read a deleted launch.
+- `tests/agentic/agentic-tool-calls-tests.md` -- manual-agent deletion and cleanup protocol.
+- `deployment/mcpb/manifest.*.json`, `src/cli/data/tool_schemas.json`, `docs/mcp_manifest.json` -- published tool metadata.
+
+## Tasks & Acceptance
+
+**Execution:**
+
+- [x] `src/services/launch_service.py` -- remove the launch GET preflight; call DELETE directly, map only an explicit 404 to `already_deleted`, and use `deleted` for successful 204 responses -- aligns behavior with the TestOps endpoint and prevents reads of deleted IDs.
+- [x] `src/tools/launches.py` -- change argument descriptions, docstring, text output, and JSON status to delete terminology; do not emit a deleted launch URL or name as confirmation -- makes the tool’s claims match the API contract.
+- [x] `tests/unit/test_launch_service.py`, `tests/unit/test_launch_tools.py`, `tests/integration/test_launch_tools.py`, `tests/e2e/test_launches.py`, and `tests/e2e/helpers/cleanup.py` -- replace archive assertions, assert no GET during deletion, cover explicit DELETE 404, and verify two direct deletions -- protect the fixed behavior at each layer and teardown.
+- [x] `tests/agentic/agentic-tool-calls-tests.md` -- exempt destructive operations from direct GET verification and add a launch-deletion cleanup step that relies on the delete confirmation -- prevents agents from probing a deleted launch.
+- [x] `deployment/mcpb/manifest.python.json`, `deployment/mcpb/manifest.uv.json`, `src/cli/data/tool_schemas.json`, and `docs/mcp_manifest.json` -- synchronize user-facing generated metadata after the tool change -- prevents stale archive terminology in packaged clients.
+
+**Acceptance Criteria:**
+
+- Given a valid launch ID, when `delete_launch` is called, then the service calls the client DELETE exactly once and never calls GET.
+- Given TestOps returns 204 for the same launch ID twice, when deletion is called twice, then both calls complete as `deleted` without a GET or 500 error.
+- Given TestOps returns 404 to DELETE, when deletion is called, then the tool returns the idempotent already-deleted message without raising an error.
+- Given TestOps returns another API error, when deletion is called, then the error propagates and the tool does not claim success.
+- Given any launch deletion output or shipped launch-tool metadata, when inspected, then it refers to deletion and contains no archived-launch wording.
+- Given the manual agentic test guide, when a launch is deleted, then its procedure does not call `get_launch` for that deleted ID.
+
+### Review Findings
+
+- [x] [Review][Patch] Missing JSON deletion-output coverage [tests/unit/test_launch_tools.py:310] — added JSON assertions for the deletion status and the absence of a launch name or URL in unit and integration coverage.
+
+## Design Notes
+
+The endpoint is already idempotent: the observed first and second direct DELETE requests both return 204. A preflight GET is therefore both unnecessary and unreliable; it also cannot safely distinguish a deleted launch because this TestOps instance responds with 500 rather than 404. A 204 confirms that TestOps accepted the requested deletion, so the tool reports `deleted`; only an explicit DELETE 404 produces `already_deleted`.
+
+## Verification
+
+**Commands:**
+
+- `uv run pytest tests/unit/test_launch_service.py tests/unit/test_launch_tools.py tests/integration/test_launch_tools.py -q` -- expected: deletion semantics and rendered output pass.
+- `uv run --env-file .env.test pytest tests/e2e/test_launches.py::test_create_close_reopen_launch_lifecycle -q` -- expected: two direct deletes pass against TestOps.
+- `uv run ruff check src/services/launch_service.py src/tools/launches.py tests/unit/test_launch_service.py tests/unit/test_launch_tools.py tests/integration/test_launch_tools.py tests/e2e/test_launches.py` -- expected: no lint findings.
+- `uv run mypy src` -- expected: no type errors.
+- `uv run fastmcp inspect src/main.py --format mcp -o docs/mcp_manifest.json && uv run python scripts/build_tool_schema.py` -- expected: generated metadata contains delete-only launch wording.

--- a/src/cli/data/tool_schemas.json
+++ b/src/cli/data/tool_schemas.json
@@ -1058,14 +1058,14 @@
     "name": "delete_launch",
     "entity": "launch",
     "action": "delete",
-    "description": "Delete/archive a launch by ID.\n\u26a0\ufe0f CAUTION: Destructive.\n\nArgs:\n    launch_id: The unique ID of the launch to archive.\n    project_id: Optional override for the default Project ID.\n    output_format: Output format: 'json' (default) or 'plain'.\n\nReturns:\n    Confirmation message with launch ID and idempotent status.",
+    "description": "Delete a launch by ID.\n\u26a0\ufe0f CAUTION: Destructive.\n\nArgs:\n    launch_id: The unique ID of the launch to delete.\n    project_id: Optional override for the default Project ID.\n    output_format: Output format: 'json' (default) or 'plain'.\n\nReturns:\n    Confirmation message with launch ID and idempotent status.",
     "input_schema": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
         "launch_id": {
           "type": "integer",
-          "description": "Launch ID to delete/archive (required)."
+          "description": "Launch ID to delete (required)."
         },
         "project_id": {
           "anyOf": [

--- a/src/services/launch_service.py
+++ b/src/services/launch_service.py
@@ -89,9 +89,8 @@ class LaunchDeleteResult:
     """Result of a launch delete operation."""
 
     launch_id: int
-    status: Literal["archived", "already_deleted"]
+    status: Literal["deleted", "already_deleted"]
     message: str
-    name: str | None = None
 
 
 @dataclass
@@ -925,26 +924,23 @@ class LaunchService:
         return "scheduled"
 
     async def delete_launch(self, launch_id: int) -> LaunchDeleteResult:
-        """Delete/archive a launch by ID with idempotent behavior."""
+        """Delete a launch by ID with idempotent behavior."""
         self._validate_project_id(self._project_id)
         self._validate_launch_id(launch_id)
 
         try:
-            launch = await self.get_launch(launch_id)
-        except LaunchNotFoundError:
+            await self._client.delete_launch(launch_id)
+        except AllureNotFoundError:
             return LaunchDeleteResult(
                 launch_id=launch_id,
                 status="already_deleted",
-                message=f"Launch {launch_id} was already archived or doesn't exist.",
+                message=f"Launch {launch_id} was already deleted or doesn't exist.",
             )
-
-        await self._client.delete_launch(launch_id)
 
         return LaunchDeleteResult(
             launch_id=launch_id,
-            status="archived",
-            name=launch.name,
-            message=f"Launch {launch_id} has been archived.",
+            status="deleted",
+            message=f"Launch {launch_id} was deleted.",
         )
 
     async def validate_launch_query(self, rql: str) -> tuple[bool, int | None]:

--- a/src/tools/launches.py
+++ b/src/tools/launches.py
@@ -563,17 +563,17 @@ async def add_test_step_attachment(
 
 
 async def delete_launch(
-    launch_id: Annotated[int, Field(description="Launch ID to delete/archive (required).")],
+    launch_id: Annotated[int, Field(description="Launch ID to delete (required).")],
     project_id: Annotated[int | None, Field(description="Optional override for the default Project ID.")] = None,
     output_format: Annotated[OutputFormat | None, Field(description="Output format: 'json' (default) or 'plain'.")] = (
         DEFAULT_OUTPUT_FORMAT
     ),
 ) -> ToolOutput:
-    """Delete/archive a launch by ID.
+    """Delete a launch by ID.
     ⚠️ CAUTION: Destructive.
 
     Args:
-        launch_id: The unique ID of the launch to archive.
+        launch_id: The unique ID of the launch to delete.
         project_id: Optional override for the default Project ID.
         output_format: Output format: 'json' (default) or 'plain'.
 
@@ -583,18 +583,13 @@ async def delete_launch(
     async with _launch_client_context(project_id=project_id) as client:
         service = LaunchService(client=client)
         result = await service.delete_launch(launch_id)
-        base_url = client.get_base_url()
-        resolved_project_id = client.get_project()
-        url = launch_url(base_url, resolved_project_id, result.launch_id)
 
     return render_output(
-        plain=f"{_format_launch_delete(result)}\nLaunch URL: {url}",
+        plain=_format_launch_delete(result),
         json_payload={
             "launch_id": result.launch_id,
-            "name": result.name,
             "status": result.status,
             "message": result.message,
-            "url": url,
         },
         output_format=output_format,
     )
@@ -833,10 +828,9 @@ def _append_statistic_lines(lines: list[str], launch: object) -> None:
 
 def _format_launch_delete(result: LaunchDeleteResult) -> str:
     if result.status == "already_deleted":
-        return f"ℹ️ Launch {result.launch_id} was already archived or doesn't exist."  # noqa: RUF001
+        return f"ℹ️ Launch {result.launch_id} was already deleted or doesn't exist."  # noqa: RUF001
 
-    name_part = f": '{result.name}'" if result.name else ""
-    return f"✅ Archived Launch {result.launch_id}{name_part}"
+    return f"✅ Deleted Launch {result.launch_id}"
 
 
 def _format_launch_test_result_list(result: LaunchTestResultListResult) -> str:

--- a/tests/agentic/agentic-tool-calls-tests.md
+++ b/tests/agentic/agentic-tool-calls-tests.md
@@ -12,7 +12,7 @@ Validate **manual tool calls for every MCP tool** using scenarios derived from `
 To ensure robust end-to-end validation, any AI agent executing this plan MUST follow these rules:
 
 1.  **Strict QA Persona**: Adopt a persona of a meticulous QA Engineer. Do not assume success; verify it explicitly.
-2.  **Explicit Verification**: After every "Write" operation (create/update/delete), you MUST perform a "Read" operation (list/get) to verify the state change, even if the tool reports success.
+2.  **Explicit Verification**: After every create or update, perform a "Read" operation (list/get) to verify the state change, even if the tool reports success. After a delete, treat the tool confirmation as the final operation for that ID; do not call a direct `get` on the deleted resource. Use a collection list only when the scenario explicitly requires absence verification.
 3.  **Data Isolation**: Use unique identifiers for test data (e.g., prefixes like `[Agent-QA]`) to avoid collisions with production or other test data.
 4.  **State Management**: Capture IDs returned by tools into variables (e.g., `TC_ID`, `LAUNCH_ID`) and reuse them in subsequent steps.
 5.  **Output Parsing**: Compare actual tool outputs against the "Expectation" strings provided in scenarios. Report any semantic or structural deviations.
@@ -62,7 +62,7 @@ From `src/tools/__init__.py:24-79`:
 - `get_custom_fields`, `get_test_case_custom_fields`
 - `create_custom_field_value`, `list_custom_field_values`, `update_custom_field_value`, `delete_custom_field_value`
 - `delete_unused_custom_fields`
-- `create_launch`, `list_launches`, `get_launch`, `upload_test_results`, `list_launch_test_results`, `rerun_test_results_manually`, `start_manual_test_session`, `submit_manual_test_results`, `add_test_result_attachment`, `add_test_step_attachment`
+- `create_launch`, `list_launches`, `get_launch`, `delete_launch`, `upload_test_results`, `list_launch_test_results`, `rerun_test_results_manually`, `start_manual_test_session`, `submit_manual_test_results`, `add_test_result_attachment`, `add_test_step_attachment`
 - `create_shared_step`, `list_shared_steps`, `update_shared_step`, `delete_shared_step`
 - `delete_archived_shared_steps`
 - `link_shared_step`, `unlink_shared_step`
@@ -252,6 +252,9 @@ From `src/tools/__init__.py:24-79`:
       - Expectation: Output shows the rerun result in a terminal state (`passed` or `failed`) and contains no rows with `status: null` or other in-progress markers.
   13. **Close Launch**: `close_launch(launch_id=LAUNCH_ID)`
       - Expectation: Output confirms the launch is closed (for example `closed=true` or equivalent terminal state).
+  14. **Delete Launch**: `delete_launch(launch_id=LAUNCH_ID)`
+      - Expectation: Output contains `Deleted Launch LAUNCH_ID`.
+      - Verification: Do not call `get_launch` for `LAUNCH_ID` after deletion; the delete confirmation is the terminal verification for this resource.
 
 #### 9. Custom Field Values Lifecycle
 - **Scenario source**: `specs/implementation-artifacts/3-11-crud-custom-field-values.md`

--- a/tests/e2e/helpers/cleanup.py
+++ b/tests/e2e/helpers/cleanup.py
@@ -3,7 +3,6 @@
 import asyncio
 
 from src.client import AllureClient
-from src.client.exceptions import LaunchNotFoundError
 from src.services import (
     CustomFieldValueService,
     DefectService,
@@ -126,7 +125,7 @@ class CleanupTracker:
         self._launches.append(launch_id)
 
     async def delete_launch_strict(self, launch_id: int, retries: int = 3, delay: float = 0.2) -> None:
-        """Delete launch and verify it no longer exists with retries.
+        """Delete a launch with retries.
 
         Args:
             launch_id: ID of the launch to delete
@@ -134,16 +133,25 @@ class CleanupTracker:
             delay: Delay between attempts in seconds
 
         Raises:
-            AssertionError: If launch still exists after all retries
+            AssertionError: If deletion does not complete after all retries
         """
         service = LaunchService(client=self._client)
+        last_error: Exception | None = None
+
         for _ in range(retries):
-            await service.delete_launch(launch_id)
-            if not await self._launch_exists(service, launch_id):
-                return
+            try:
+                result = await service.delete_launch(launch_id)
+            except Exception as exc:  # pragma: no cover - defensive teardown path
+                last_error = exc
+            else:
+                if result.status in {"deleted", "already_deleted"}:
+                    return
+
             await asyncio.sleep(delay)
 
-        raise AssertionError(f"Launch {launch_id} still exists after deletion attempts")
+        if last_error is not None:
+            raise AssertionError(f"Launch {launch_id} could not be deleted: {last_error}") from last_error
+        raise AssertionError(f"Launch {launch_id} could not be deleted")
 
     async def delete_test_case_strict(
         self, service: TestCaseService, test_case_id: int, retries: int = 3, delay: float = 0.2
@@ -181,14 +189,6 @@ class CleanupTracker:
         await self._cleanup_defects()
         await self._cleanup_custom_field_values()
         await self._cleanup_launches()
-
-    @staticmethod
-    async def _launch_exists(service: LaunchService, launch_id: int) -> bool:
-        try:
-            await service.get_launch(launch_id)
-            return True
-        except LaunchNotFoundError:
-            return False
 
     async def _cleanup_test_cases(self) -> None:
         import logging

--- a/tests/e2e/test_launches.py
+++ b/tests/e2e/test_launches.py
@@ -40,11 +40,11 @@ async def test_create_close_reopen_launch_lifecycle(allure_client, project_id, t
 
         deleted = await service.delete_launch(created.id)
         assert deleted.launch_id == created.id
-        assert deleted.status == "archived"
+        assert deleted.status == "deleted"
 
         deleted_again = await service.delete_launch(created.id)
         assert deleted_again.launch_id == created.id
-        assert deleted_again.status == "already_deleted"
+        assert deleted_again.status == "deleted"
     finally:
         if created_id is not None:
             await cleanup_tracker.delete_launch_strict(created_id)

--- a/tests/integration/test_launch_tools.py
+++ b/tests/integration/test_launch_tools.py
@@ -217,7 +217,7 @@ async def test_upload_test_results_tool_renders_partial_failure_indexes() -> Non
 
 
 @pytest.mark.asyncio
-async def test_delete_launch_tool_output_archived() -> None:
+async def test_delete_launch_tool_output_deleted() -> None:
     with patch("src.tools.launches.resolve_auth_settings", return_value=_resolved_auth()):
         with patch("src.tools.launches.AllureClient") as mock_client_cls:
             mock_client = _mock_url_context()
@@ -228,15 +228,14 @@ async def test_delete_launch_tool_output_archived() -> None:
                 mock_result = type(
                     "LaunchDeleteResult",
                     (),
-                    {"launch_id": 55, "status": "archived", "name": "Launch 55", "message": "Archived"},
+                    {"launch_id": 55, "status": "deleted", "message": "Deleted"},
                 )
                 mock_service.delete_launch = AsyncMock(return_value=mock_result)
 
                 output = await delete_launch(launch_id=55, output_format="plain")
 
-                assert "Archived Launch 55" in output
-                assert "Launch 55" in output
-                assert "Launch URL: https://example.com/launch/55" in output
+                assert "Deleted Launch 55" in output
+                assert "Launch URL" not in output
                 mock_service.delete_launch.assert_called_once_with(55)
 
 
@@ -255,8 +254,7 @@ async def test_delete_launch_tool_output_already_deleted() -> None:
                     {
                         "launch_id": 56,
                         "status": "already_deleted",
-                        "name": None,
-                        "message": "Already archived",
+                        "message": "Already deleted",
                     },
                 )
                 mock_service.delete_launch = AsyncMock(return_value=mock_result)
@@ -264,8 +262,8 @@ async def test_delete_launch_tool_output_already_deleted() -> None:
                 output = await delete_launch(launch_id=56, output_format="plain")
 
                 assert "Launch 56" in output
-                assert "already archived or doesn't exist" in output
-                assert "Launch URL: https://example.com/launch/56" in output
+                assert "already deleted or doesn't exist" in output
+                assert "Launch URL" not in output
                 mock_service.delete_launch.assert_called_once_with(56)
 
 

--- a/tests/integration/test_launch_tools.py
+++ b/tests/integration/test_launch_tools.py
@@ -240,6 +240,37 @@ async def test_delete_launch_tool_output_deleted() -> None:
 
 
 @pytest.mark.asyncio
+async def test_delete_launch_tool_json_output_already_deleted_omits_launch_details() -> None:
+    with patch("src.tools.launches.resolve_auth_settings", return_value=_resolved_auth()):
+        with patch("src.tools.launches.AllureClient") as mock_client_cls:
+            mock_client = _mock_url_context()
+            mock_client_cls.return_value.__aenter__.return_value = mock_client
+
+            with patch("src.tools.launches.LaunchService") as mock_service_cls:
+                mock_service = mock_service_cls.return_value
+                mock_result = type(
+                    "LaunchDeleteResult",
+                    (),
+                    {
+                        "launch_id": 56,
+                        "status": "already_deleted",
+                        "message": "Already deleted",
+                    },
+                )
+                mock_service.delete_launch = AsyncMock(return_value=mock_result)
+
+                output = await delete_launch(launch_id=56, output_format="json")
+
+                assert output.structured_content == {
+                    "launch_id": 56,
+                    "status": "already_deleted",
+                    "message": "Already deleted",
+                }
+                assert "name" not in output.structured_content
+                assert "url" not in output.structured_content
+
+
+@pytest.mark.asyncio
 async def test_delete_launch_tool_output_already_deleted() -> None:
     with patch("src.tools.launches.resolve_auth_settings", return_value=_resolved_auth()):
         with patch("src.tools.launches.AllureClient") as mock_client_cls:

--- a/tests/unit/test_launch_service.py
+++ b/tests/unit/test_launch_service.py
@@ -276,15 +276,13 @@ async def test_get_launch_not_found_maps_error(service: LaunchService, mock_clie
 
 @pytest.mark.asyncio
 async def test_delete_launch_success(service: LaunchService, mock_client: MagicMock) -> None:
-    launch = LaunchDto(id=88, name="To Delete")
-    mock_client.get_launch.return_value = launch
-
     result = await service.delete_launch(88)
 
     assert isinstance(result, LaunchDeleteResult)
     assert result.launch_id == 88
-    assert result.status == "archived"
-    assert result.name == "To Delete"
+    assert result.status == "deleted"
+    assert result.message == "Launch 88 was deleted."
+    mock_client.get_launch.assert_not_called()
     mock_client.delete_launch.assert_called_once_with(88)
 
 
@@ -296,14 +294,39 @@ async def test_delete_launch_invalid_id(service: LaunchService) -> None:
 
 @pytest.mark.asyncio
 async def test_delete_launch_already_deleted(service: LaunchService, mock_client: MagicMock) -> None:
-    mock_client.get_launch.side_effect = AllureNotFoundError("Not found", status_code=404, response_body="{}")
+    mock_client.delete_launch.side_effect = AllureNotFoundError("Not found", status_code=404, response_body="{}")
 
     result = await service.delete_launch(99)
 
     assert result.launch_id == 99
     assert result.status == "already_deleted"
-    assert "already archived" in result.message
-    mock_client.delete_launch.assert_not_called()
+    assert "already deleted" in result.message
+    mock_client.get_launch.assert_not_called()
+    mock_client.delete_launch.assert_called_once_with(99)
+
+
+@pytest.mark.asyncio
+async def test_delete_launch_repeated_success_does_not_fetch_deleted_launch(
+    service: LaunchService, mock_client: MagicMock
+) -> None:
+    first_result = await service.delete_launch(99)
+    second_result = await service.delete_launch(99)
+
+    assert first_result.status == "deleted"
+    assert second_result.status == "deleted"
+    mock_client.get_launch.assert_not_called()
+    assert mock_client.delete_launch.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_delete_launch_propagates_non_not_found_api_error(service: LaunchService, mock_client: MagicMock) -> None:
+    mock_client.delete_launch.side_effect = AllureAPIError("Server error", status_code=500, response_body="{}")
+
+    with pytest.raises(AllureAPIError, match="Server error"):
+        await service.delete_launch(99)
+
+    mock_client.get_launch.assert_not_called()
+    mock_client.delete_launch.assert_called_once_with(99)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_launch_tools.py
+++ b/tests/unit/test_launch_tools.py
@@ -292,7 +292,7 @@ async def test_submit_manual_test_results_and_attachment_outputs() -> None:
 
 
 @pytest.mark.asyncio
-async def test_delete_launch_output_archived() -> None:
+async def test_delete_launch_output_deleted() -> None:
     with patch("src.tools.launches.resolve_auth_settings", return_value=_resolved_auth()):
         with patch("src.tools.launches.AllureClient") as mock_client_cls:
             mock_client = _mock_url_context()
@@ -303,14 +303,14 @@ async def test_delete_launch_output_archived() -> None:
                 mock_result = type(
                     "LaunchDeleteResult",
                     (),
-                    {"launch_id": 42, "status": "archived", "name": "Launch 42", "message": "Archived"},
+                    {"launch_id": 42, "status": "deleted", "message": "Deleted"},
                 )
                 mock_service.delete_launch = AsyncMock(return_value=mock_result)
 
                 output = await delete_launch(launch_id=42, output_format="plain")
 
-                assert "Archived Launch 42" in output
-                assert "Launch 42" in output
+                assert "Deleted Launch 42" in output
+                assert "Launch URL" not in output
 
 
 @pytest.mark.asyncio
@@ -328,7 +328,6 @@ async def test_delete_launch_output_already_deleted() -> None:
                     {
                         "launch_id": 77,
                         "status": "already_deleted",
-                        "name": None,
                         "message": "Already deleted",
                     },
                 )
@@ -337,7 +336,7 @@ async def test_delete_launch_output_already_deleted() -> None:
                 output = await delete_launch(launch_id=77, output_format="plain")
 
                 assert "Launch 77" in output
-                assert "already archived or doesn't exist" in output
+                assert "already deleted or doesn't exist" in output
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_launch_tools.py
+++ b/tests/unit/test_launch_tools.py
@@ -314,6 +314,33 @@ async def test_delete_launch_output_deleted() -> None:
 
 
 @pytest.mark.asyncio
+async def test_delete_launch_json_output_deleted_omits_launch_details() -> None:
+    with patch("src.tools.launches.resolve_auth_settings", return_value=_resolved_auth()):
+        with patch("src.tools.launches.AllureClient") as mock_client_cls:
+            mock_client = _mock_url_context()
+            mock_client_cls.return_value.__aenter__.return_value = mock_client
+
+            with patch("src.tools.launches.LaunchService") as mock_service_cls:
+                mock_service = mock_service_cls.return_value
+                mock_result = type(
+                    "LaunchDeleteResult",
+                    (),
+                    {"launch_id": 42, "status": "deleted", "message": "Deleted"},
+                )
+                mock_service.delete_launch = AsyncMock(return_value=mock_result)
+
+                output = await delete_launch(launch_id=42, output_format="json")
+
+                assert output.structured_content == {
+                    "launch_id": 42,
+                    "status": "deleted",
+                    "message": "Deleted",
+                }
+                assert "name" not in output.structured_content
+                assert "url" not in output.structured_content
+
+
+@pytest.mark.asyncio
 async def test_delete_launch_output_already_deleted() -> None:
     with patch("src.tools.launches.resolve_auth_settings", return_value=_resolved_auth()):
         with patch("src.tools.launches.AllureClient") as mock_client_cls:


### PR DESCRIPTION
## Description

Make launch deletion use the authoritative DELETE response instead of a GET preflight. Successful DELETE calls report `deleted`; an explicit DELETE 404 reports `already_deleted`. Update user-facing metadata, cleanup guidance, and regression coverage, including JSON output that omits deleted launch names and URLs.

## Type of Change

- [x] 🐛 Bug fix
- [ ] 🧹 Refactoring
- [ ] 📝 Documentation
- [x] 🧪 Testing update
- [ ] 🔧 Infrastructure/Configuration

## Related Issues/Stories

Fix launch deletion semantics — `spec-fix-launch-deletion-semantics.md`.

## How Has This Been Tested?

- `uv run pytest tests/unit/test_launch_service.py tests/unit/test_launch_tools.py tests/integration/test_launch_tools.py -q`
- `uv run ruff check src/services/launch_service.py src/tools/launches.py tests/unit/test_launch_service.py tests/unit/test_launch_tools.py tests/integration/test_launch_tools.py tests/e2e/test_launches.py`
- `uv run mypy src`
- Pre-push checks passed.

The local full suite passed formatting, linting, mypy, unit/integration, and documentation stages. CLI-binary packaging tests were intentionally skipped. A separate pre-existing live-E2E auth-response failure is deferred to its own PR.

## Checklist

- [x] PR is human-reviewed.
- [x] Documentation has been updated (if applicable).
- [x] Tests have been added or updated to cover changes.