### PR TITLE
fix: inspect FastMCP tools in MCPB validation

### DIFF
--- a/deployment/scripts/validate_mcpb.py
+++ b/deployment/scripts/validate_mcpb.py
@@ -68,17 +68,17 @@ def validate_server_entry_point(manifest):
 
 def validate_tools(manifest, mcp_instance):
     if not mcp_instance:
-        print("⚠️  Skipping tool validation against code")
-        return
+        print("❌ Could not inspect FastMCP tools: no FastMCP instance found")
+        sys.exit(1)
 
     manifest_tools = {t["name"] for t in manifest.get("tools", [])}
     # Use FastMCP's public async API. The former private _tool_manager registry
     # was removed in FastMCP 3.x.
     try:
         code_tools = {tool.name for tool in asyncio.run(mcp_instance.list_tools(run_middleware=False))}
-    except Exception:
-        print("⚠️  Could not inspect FastMCP tools directly")
-        return
+    except Exception as e:
+        print(f"❌ Could not inspect FastMCP tools: {e}")
+        sys.exit(1)
 
     print(f"ℹ️  Manifest tools: {len(manifest_tools)}")
     print(f"ℹ️  Code tools: {len(code_tools)}")

--- a/deployment/scripts/validate_mcpb.py
+++ b/deployment/scripts/validate_mcpb.py
@@ -1,3 +1,4 @@
+import asyncio
 import importlib.util
 import json
 import sys
@@ -71,17 +72,10 @@ def validate_tools(manifest, mcp_instance):
         return
 
     manifest_tools = {t["name"] for t in manifest.get("tools", [])}
-    # FastMCP stores tools in _tool_manager.tools usually, or we can access the underlying tools
-    # Inspecting FastMCP internals might be fragile, but let's try to see if we can get the list.
-    # FastMCP uses a ToolManager.
-
-    code_tools = set()
-    # Attempt to list tools from mcp instance
-    # Depending on FastMCP version. assuming >= 0.3.0
+    # Use FastMCP's public async API. The former private _tool_manager registry
+    # was removed in FastMCP 3.x.
     try:
-        # This part is heuristic based on standard FastMCP usage
-        for tool_name in mcp_instance._tool_manager._tools.keys():
-            code_tools.add(tool_name)
+        code_tools = {tool.name for tool in asyncio.run(mcp_instance.list_tools(run_middleware=False))}
     except Exception:
         print("⚠️  Could not inspect FastMCP tools directly")
         return

--- a/tests/packaging/test_validate_mcpb.py
+++ b/tests/packaging/test_validate_mcpb.py
@@ -1,0 +1,38 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+SCRIPT_PATH = Path("deployment/scripts/validate_mcpb.py")
+
+
+def _load_script_module():
+    spec = importlib.util.spec_from_file_location("validate_mcpb", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _BrokenFastMCP:
+    async def list_tools(self, *, run_middleware: bool):
+        raise RuntimeError("tool registry unavailable")
+
+
+def test_validate_tools_fails_when_fastmcp_tools_cannot_be_inspected(capsys: pytest.CaptureFixture[str]) -> None:
+    module = _load_script_module()
+
+    with pytest.raises(SystemExit, match="1"):
+        module.validate_tools({"tools": []}, _BrokenFastMCP())
+
+    assert "❌ Could not inspect FastMCP tools: tool registry unavailable" in capsys.readouterr().out
+
+
+def test_validate_tools_fails_without_a_fastmcp_instance(capsys: pytest.CaptureFixture[str]) -> None:
+    module = _load_script_module()
+
+    with pytest.raises(SystemExit, match="1"):
+        module.validate_tools({"tools": []}, None)
+
+    assert "❌ Could not inspect FastMCP tools: no FastMCP instance found" in capsys.readouterr().out


### PR DESCRIPTION
## Description

Replace the removed private FastMCP tool-manager access in MCPB validation with the supported asynchronous tool-listing API. This restores code-versus-manifest tool validation for FastMCP 3.x.

## Type of Change

- [ ] ✨ New feature
- [x] 🐛 Bug fix
- [ ] 🧹 Refactoring
- [ ] 📝 Documentation
- [ ] 🚀 Release/Deployment
- [ ] 🧪 Testing update
- [ ] 🔧 Infrastructure/Configuration

## Related Issues/Stories

None.

## How Has This Been Tested?

- `uv run python deployment/scripts/validate_mcpb.py uv`
- `uv run python deployment/scripts/validate_mcpb.py python`
- `uv run ruff check deployment/scripts/validate_mcpb.py`
- `uv run pytest tests/packaging/test_mcpb_manifests.py -q`
- `uv run pytest tests/unit tests/integration tests/docs tests/packaging --ignore=tests/packaging/test_cli_binaries.py`

## Checklist

- [x] PR is human-reviewed.
- [x] Documentation has been updated (if applicable).
- [ ] Tests have been added or updated to cover changes.