### PR TITLE
feat(tools): refine MCP output schema contracts

### DIFF
--- a/docs/mcp_manifest.json
+++ b/docs/mcp_manifest.json
@@ -357,260 +357,26 @@
             "title": "Attachment",
             "type": "object"
           },
-          "EntitySummary": {
+          "CustomFieldEntry": {
             "additionalProperties": false,
-            "description": "Closed common vocabulary for collection entries across Lucius tools.",
+            "description": "A named custom-field value exposed by test-case details.",
             "properties": {
-              "id": {
-                "anyOf": [
-                  {
-                    "type": "integer"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "default": null,
-                "title": "Id"
-              },
               "name": {
-                "anyOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "default": null,
-                "title": "Name"
+                "description": "Custom field name.",
+                "title": "Name",
+                "type": "string"
               },
-              "key": {
-                "anyOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "default": null,
-                "title": "Key"
-              },
-              "status": {
-                "anyOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "default": null,
-                "title": "Status"
-              },
-              "url": {
-                "anyOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "default": null,
-                "title": "Url"
-              },
-              "type": {
-                "anyOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "default": null,
-                "title": "Type"
-              },
-              "closed": {
-                "anyOf": [
-                  {
-                    "type": "boolean"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "default": null,
-                "title": "Closed"
-              },
-              "tags": {
-                "anyOf": [
-                  {
-                    "items": {
-                      "type": "string"
-                    },
-                    "type": "array"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "default": null,
-                "title": "Tags"
-              },
-              "project_id": {
-                "anyOf": [
-                  {
-                    "type": "integer"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "default": null,
-                "title": "Project Id"
-              },
-              "test_case_id": {
-                "anyOf": [
-                  {
-                    "type": "integer"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "default": null,
-                "title": "Test Case Id"
-              },
-              "test_layer_id": {
-                "anyOf": [
-                  {
-                    "type": "integer"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "default": null,
-                "title": "Test Layer Id"
-              },
-              "test_layer_name": {
-                "anyOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "default": null,
-                "title": "Test Layer Name"
-              },
-              "steps_count": {
-                "anyOf": [
-                  {
-                    "minimum": 0,
-                    "type": "integer"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "default": null,
-                "title": "Steps Count"
-              },
-              "test_cases_count": {
-                "anyOf": [
-                  {
-                    "minimum": 0,
-                    "type": "integer"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "default": null,
-                "title": "Test Cases Count"
-              },
-              "required": {
-                "anyOf": [
-                  {
-                    "type": "boolean"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "default": null,
-                "title": "Required"
-              },
-              "values": {
-                "anyOf": [
-                  {
-                    "items": {
-                      "type": "string"
-                    },
-                    "type": "array"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "default": null,
-                "title": "Values"
-              },
-              "manual": {
-                "anyOf": [
-                  {
-                    "type": "boolean"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "default": null,
-                "title": "Manual"
-              },
-              "assignee": {
-                "anyOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "default": null,
-                "title": "Assignee"
-              },
-              "tested_by": {
-                "anyOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "default": null,
-                "title": "Tested By"
-              },
-              "result_id": {
-                "anyOf": [
-                  {
-                    "type": "integer"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "default": null,
-                "title": "Result Id"
+              "value": {
+                "description": "Rendered custom field value.",
+                "title": "Value",
+                "type": "string"
               }
             },
-            "title": "EntitySummary",
+            "required": [
+              "name",
+              "value"
+            ],
+            "title": "CustomFieldEntry",
             "type": "object"
           },
           "Step": {
@@ -713,6 +479,7 @@
           }
         },
         "additionalProperties": false,
+        "description": "Structured details for one test case.",
         "properties": {
           "id": {
             "anyOf": [
@@ -793,44 +560,15 @@
             "anyOf": [
               {
                 "items": {
-                  "$ref": "#/$defs/EntitySummary"
+                  "$ref": "#/$defs/CustomFieldEntry"
                 },
                 "type": "array"
-              },
-              {
-                "additionalProperties": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "integer"
-                    },
-                    {
-                      "type": "number"
-                    },
-                    {
-                      "type": "boolean"
-                    },
-                    {
-                      "items": {
-                        "type": "string"
-                      },
-                      "type": "array"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ]
-                },
-                "type": "object"
               },
               {
                 "type": "null"
               }
             ],
             "default": null,
-            "description": "Custom-field values as named entries or a value map.",
             "title": "Custom Fields"
           },
           "attachments": {
@@ -861,7 +599,6 @@
               }
             ],
             "default": null,
-            "description": "Serialized scenario steps.",
             "title": "Steps"
           },
           "url": {
@@ -877,7 +614,7 @@
             "title": "Url"
           }
         },
-        "title": "GetTestCaseDetailsOutput",
+        "title": "TestCaseDetailsOutput",
         "type": "object"
       },
       "icons": null,
@@ -1542,6 +1279,31 @@
       "outputSchema": {
         "additionalProperties": false,
         "properties": {
+          "requires_confirmation": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Requires Confirmation"
+          },
+          "action": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Requested operation name.",
+            "title": "Action"
+          },
           "deleted_count": {
             "anyOf": [
               {
@@ -2419,6 +2181,31 @@
       "outputSchema": {
         "additionalProperties": false,
         "properties": {
+          "requires_confirmation": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Requires Confirmation"
+          },
+          "action": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Requested operation name.",
+            "title": "Action"
+          },
           "deleted_count": {
             "anyOf": [
               {
@@ -3488,258 +3275,24 @@
               {
                 "items": {
                   "additionalProperties": false,
-                  "description": "Closed common vocabulary for collection entries across Lucius tools.",
+                  "description": "A named custom-field value exposed by test-case details.",
                   "properties": {
-                    "id": {
-                      "anyOf": [
-                        {
-                          "type": "integer"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Id"
-                    },
                     "name": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Name"
+                      "description": "Custom field name.",
+                      "title": "Name",
+                      "type": "string"
                     },
-                    "key": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Key"
-                    },
-                    "status": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Status"
-                    },
-                    "url": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Url"
-                    },
-                    "type": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Type"
-                    },
-                    "closed": {
-                      "anyOf": [
-                        {
-                          "type": "boolean"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Closed"
-                    },
-                    "tags": {
-                      "anyOf": [
-                        {
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Tags"
-                    },
-                    "project_id": {
-                      "anyOf": [
-                        {
-                          "type": "integer"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Project Id"
-                    },
-                    "test_case_id": {
-                      "anyOf": [
-                        {
-                          "type": "integer"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Test Case Id"
-                    },
-                    "test_layer_id": {
-                      "anyOf": [
-                        {
-                          "type": "integer"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Test Layer Id"
-                    },
-                    "test_layer_name": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Test Layer Name"
-                    },
-                    "steps_count": {
-                      "anyOf": [
-                        {
-                          "minimum": 0,
-                          "type": "integer"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Steps Count"
-                    },
-                    "test_cases_count": {
-                      "anyOf": [
-                        {
-                          "minimum": 0,
-                          "type": "integer"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Test Cases Count"
-                    },
-                    "required": {
-                      "anyOf": [
-                        {
-                          "type": "boolean"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Required"
-                    },
-                    "values": {
-                      "anyOf": [
-                        {
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Values"
-                    },
-                    "manual": {
-                      "anyOf": [
-                        {
-                          "type": "boolean"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Manual"
-                    },
-                    "assignee": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Assignee"
-                    },
-                    "tested_by": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Tested By"
-                    },
-                    "result_id": {
-                      "anyOf": [
-                        {
-                          "type": "integer"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Result Id"
+                    "value": {
+                      "description": "Rendered custom field value.",
+                      "title": "Value",
+                      "type": "string"
                     }
                   },
-                  "title": "EntitySummary",
+                  "required": [
+                    "name",
+                    "value"
+                  ],
+                  "title": "CustomFieldEntry",
                   "type": "object"
                 },
                 "type": "array"
@@ -4126,6 +3679,7 @@
       },
       "outputSchema": {
         "additionalProperties": false,
+        "description": "The launch fields emitted by the launch list and detail tools.",
         "properties": {
           "id": {
             "anyOf": [
@@ -4166,7 +3720,7 @@
           "created_date": {
             "anyOf": [
               {
-                "type": "string"
+                "type": "integer"
               },
               {
                 "type": "null"
@@ -4178,7 +3732,7 @@
           "last_modified_date": {
             "anyOf": [
               {
-                "type": "string"
+                "type": "integer"
               },
               {
                 "type": "null"
@@ -4226,6 +3780,7 @@
           "known_defects_count": {
             "anyOf": [
               {
+                "minimum": 0,
                 "type": "integer"
               },
               {
@@ -4238,6 +3793,7 @@
           "new_defects_count": {
             "anyOf": [
               {
+                "minimum": 0,
                 "type": "integer"
               },
               {
@@ -4284,7 +3840,7 @@
             "title": "Operation"
           }
         },
-        "title": "CreateLaunchOutput",
+        "title": "LaunchSummary",
         "type": "object"
       },
       "icons": null,
@@ -4351,6 +3907,7 @@
       },
       "outputSchema": {
         "additionalProperties": false,
+        "description": "The launch fields emitted by the launch list and detail tools.",
         "properties": {
           "id": {
             "anyOf": [
@@ -4391,7 +3948,7 @@
           "created_date": {
             "anyOf": [
               {
-                "type": "string"
+                "type": "integer"
               },
               {
                 "type": "null"
@@ -4403,7 +3960,7 @@
           "last_modified_date": {
             "anyOf": [
               {
-                "type": "string"
+                "type": "integer"
               },
               {
                 "type": "null"
@@ -4451,6 +4008,7 @@
           "known_defects_count": {
             "anyOf": [
               {
+                "minimum": 0,
                 "type": "integer"
               },
               {
@@ -4463,6 +4021,7 @@
           "new_defects_count": {
             "anyOf": [
               {
+                "minimum": 0,
                 "type": "integer"
               },
               {
@@ -4509,7 +4068,7 @@
             "title": "Operation"
           }
         },
-        "title": "GetLaunchOutput",
+        "title": "LaunchSummary",
         "type": "object"
       },
       "icons": null,
@@ -4619,13 +4178,66 @@
       },
       "outputSchema": {
         "additionalProperties": false,
+        "description": "Paginated launch summaries.",
         "properties": {
+          "total": {
+            "anyOf": [
+              {
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Total"
+          },
+          "page": {
+            "anyOf": [
+              {
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Page"
+          },
+          "size": {
+            "anyOf": [
+              {
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Size"
+          },
+          "total_pages": {
+            "anyOf": [
+              {
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Total Pages"
+          },
           "items": {
             "anyOf": [
               {
                 "items": {
                   "additionalProperties": false,
-                  "description": "Closed common vocabulary for collection entries across Lucius tools.",
+                  "description": "The launch fields emitted by the launch list and detail tools.",
                   "properties": {
                     "id": {
                       "anyOf": [
@@ -4651,54 +4263,6 @@
                       "default": null,
                       "title": "Name"
                     },
-                    "key": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Key"
-                    },
-                    "status": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Status"
-                    },
-                    "url": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Url"
-                    },
-                    "type": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Type"
-                    },
                     "closed": {
                       "anyOf": [
                         {
@@ -4711,20 +4275,29 @@
                       "default": null,
                       "title": "Closed"
                     },
-                    "tags": {
+                    "created_date": {
                       "anyOf": [
                         {
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
+                          "type": "integer"
                         },
                         {
                           "type": "null"
                         }
                       ],
                       "default": null,
-                      "title": "Tags"
+                      "title": "Created Date"
+                    },
+                    "last_modified_date": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null,
+                      "title": "Last Modified Date"
                     },
                     "project_id": {
                       "anyOf": [
@@ -4738,43 +4311,31 @@
                       "default": null,
                       "title": "Project Id"
                     },
-                    "test_case_id": {
+                    "autoclose": {
                       "anyOf": [
                         {
-                          "type": "integer"
+                          "type": "boolean"
                         },
                         {
                           "type": "null"
                         }
                       ],
                       "default": null,
-                      "title": "Test Case Id"
+                      "title": "Autoclose"
                     },
-                    "test_layer_id": {
+                    "external": {
                       "anyOf": [
                         {
-                          "type": "integer"
+                          "type": "boolean"
                         },
                         {
                           "type": "null"
                         }
                       ],
                       "default": null,
-                      "title": "Test Layer Id"
+                      "title": "External"
                     },
-                    "test_layer_name": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Test Layer Name"
-                    },
-                    "steps_count": {
+                    "known_defects_count": {
                       "anyOf": [
                         {
                           "minimum": 0,
@@ -4785,9 +4346,9 @@
                         }
                       ],
                       "default": null,
-                      "title": "Steps Count"
+                      "title": "Known Defects Count"
                     },
-                    "test_cases_count": {
+                    "new_defects_count": {
                       "anyOf": [
                         {
                           "minimum": 0,
@@ -4798,48 +4359,9 @@
                         }
                       ],
                       "default": null,
-                      "title": "Test Cases Count"
+                      "title": "New Defects Count"
                     },
-                    "required": {
-                      "anyOf": [
-                        {
-                          "type": "boolean"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Required"
-                    },
-                    "values": {
-                      "anyOf": [
-                        {
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Values"
-                    },
-                    "manual": {
-                      "anyOf": [
-                        {
-                          "type": "boolean"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Manual"
-                    },
-                    "assignee": {
+                    "manual_execution_guidance": {
                       "anyOf": [
                         {
                           "type": "string"
@@ -4849,9 +4371,9 @@
                         }
                       ],
                       "default": null,
-                      "title": "Assignee"
+                      "title": "Manual Execution Guidance"
                     },
-                    "tested_by": {
+                    "url": {
                       "anyOf": [
                         {
                           "type": "string"
@@ -4861,22 +4383,22 @@
                         }
                       ],
                       "default": null,
-                      "title": "Tested By"
+                      "title": "Url"
                     },
-                    "result_id": {
+                    "operation": {
                       "anyOf": [
                         {
-                          "type": "integer"
+                          "type": "string"
                         },
                         {
                           "type": "null"
                         }
                       ],
                       "default": null,
-                      "title": "Result Id"
+                      "title": "Operation"
                     }
                   },
-                  "title": "EntitySummary",
+                  "title": "LaunchSummary",
                   "type": "object"
                 },
                 "type": "array"
@@ -4886,56 +4408,7 @@
               }
             ],
             "default": null,
-            "description": "Entity-specific collection entries.",
             "title": "Items"
-          },
-          "total": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "title": "Total"
-          },
-          "page": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "title": "Page"
-          },
-          "size": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "title": "Size"
-          },
-          "total_pages": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "title": "Total Pages"
           }
         },
         "title": "ListLaunchesOutput",
@@ -6564,6 +6037,7 @@
       },
       "outputSchema": {
         "additionalProperties": false,
+        "description": "The launch fields emitted by the launch list and detail tools.",
         "properties": {
           "id": {
             "anyOf": [
@@ -6604,7 +6078,7 @@
           "created_date": {
             "anyOf": [
               {
-                "type": "string"
+                "type": "integer"
               },
               {
                 "type": "null"
@@ -6616,7 +6090,7 @@
           "last_modified_date": {
             "anyOf": [
               {
-                "type": "string"
+                "type": "integer"
               },
               {
                 "type": "null"
@@ -6664,6 +6138,7 @@
           "known_defects_count": {
             "anyOf": [
               {
+                "minimum": 0,
                 "type": "integer"
               },
               {
@@ -6676,6 +6151,7 @@
           "new_defects_count": {
             "anyOf": [
               {
+                "minimum": 0,
                 "type": "integer"
               },
               {
@@ -6722,7 +6198,7 @@
             "title": "Operation"
           }
         },
-        "title": "CloseLaunchOutput",
+        "title": "LaunchSummary",
         "type": "object"
       },
       "icons": null,
@@ -6801,6 +6277,7 @@
       },
       "outputSchema": {
         "additionalProperties": false,
+        "description": "The launch fields emitted by the launch list and detail tools.",
         "properties": {
           "id": {
             "anyOf": [
@@ -6841,7 +6318,7 @@
           "created_date": {
             "anyOf": [
               {
-                "type": "string"
+                "type": "integer"
               },
               {
                 "type": "null"
@@ -6853,7 +6330,7 @@
           "last_modified_date": {
             "anyOf": [
               {
-                "type": "string"
+                "type": "integer"
               },
               {
                 "type": "null"
@@ -6901,6 +6378,7 @@
           "known_defects_count": {
             "anyOf": [
               {
+                "minimum": 0,
                 "type": "integer"
               },
               {
@@ -6913,6 +6391,7 @@
           "new_defects_count": {
             "anyOf": [
               {
+                "minimum": 0,
                 "type": "integer"
               },
               {
@@ -6959,7 +6438,7 @@
             "title": "Operation"
           }
         },
-        "title": "ReopenLaunchOutput",
+        "title": "LaunchSummary",
         "type": "object"
       },
       "icons": null,
@@ -8252,6 +7731,31 @@
       "outputSchema": {
         "additionalProperties": false,
         "properties": {
+          "requires_confirmation": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Requires Confirmation"
+          },
+          "action": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Requested operation name.",
+            "title": "Action"
+          },
           "deleted_count": {
             "anyOf": [
               {
@@ -10663,265 +10167,310 @@
         "type": "object"
       },
       "outputSchema": {
+        "$defs": {
+          "EntitySummary": {
+            "additionalProperties": false,
+            "description": "Closed common vocabulary for collection entries across Lucius tools.",
+            "properties": {
+              "id": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Id"
+              },
+              "name": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Name"
+              },
+              "key": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Key"
+              },
+              "status": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Status"
+              },
+              "url": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Url"
+              },
+              "type": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Type"
+              },
+              "closed": {
+                "anyOf": [
+                  {
+                    "type": "boolean"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Closed"
+              },
+              "tags": {
+                "anyOf": [
+                  {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Tags"
+              },
+              "project_id": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Project Id"
+              },
+              "test_case_id": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Test Case Id"
+              },
+              "test_layer_id": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Test Layer Id"
+              },
+              "test_layer_name": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Test Layer Name"
+              },
+              "steps_count": {
+                "anyOf": [
+                  {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Steps Count"
+              },
+              "test_cases_count": {
+                "anyOf": [
+                  {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Test Cases Count"
+              },
+              "required": {
+                "anyOf": [
+                  {
+                    "type": "boolean"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Required"
+              },
+              "values": {
+                "anyOf": [
+                  {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Values"
+              },
+              "manual": {
+                "anyOf": [
+                  {
+                    "type": "boolean"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Manual"
+              },
+              "assignee": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Assignee"
+              },
+              "tested_by": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Tested By"
+              },
+              "result_id": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Result Id"
+              }
+            },
+            "title": "EntitySummary",
+            "type": "object"
+          },
+          "SuiteNodeOutput": {
+            "additionalProperties": false,
+            "description": "A recursive hierarchy-suite node.",
+            "properties": {
+              "id": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Id"
+              },
+              "name": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Name"
+              },
+              "children": {
+                "items": {
+                  "$ref": "#/$defs/SuiteNodeOutput"
+                },
+                "title": "Children",
+                "type": "array"
+              }
+            },
+            "title": "SuiteNodeOutput",
+            "type": "object"
+          }
+        },
         "additionalProperties": false,
+        "description": "Hierarchy tree and its recursive suite nodes.",
         "properties": {
           "tree": {
             "anyOf": [
               {
-                "additionalProperties": false,
-                "description": "Closed common vocabulary for collection entries across Lucius tools.",
-                "properties": {
-                  "id": {
-                    "anyOf": [
-                      {
-                        "type": "integer"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Id"
-                  },
-                  "name": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Name"
-                  },
-                  "key": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Key"
-                  },
-                  "status": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Status"
-                  },
-                  "url": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Url"
-                  },
-                  "type": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Type"
-                  },
-                  "closed": {
-                    "anyOf": [
-                      {
-                        "type": "boolean"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Closed"
-                  },
-                  "tags": {
-                    "anyOf": [
-                      {
-                        "items": {
-                          "type": "string"
-                        },
-                        "type": "array"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Tags"
-                  },
-                  "project_id": {
-                    "anyOf": [
-                      {
-                        "type": "integer"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Project Id"
-                  },
-                  "test_case_id": {
-                    "anyOf": [
-                      {
-                        "type": "integer"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Test Case Id"
-                  },
-                  "test_layer_id": {
-                    "anyOf": [
-                      {
-                        "type": "integer"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Test Layer Id"
-                  },
-                  "test_layer_name": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Test Layer Name"
-                  },
-                  "steps_count": {
-                    "anyOf": [
-                      {
-                        "minimum": 0,
-                        "type": "integer"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Steps Count"
-                  },
-                  "test_cases_count": {
-                    "anyOf": [
-                      {
-                        "minimum": 0,
-                        "type": "integer"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Test Cases Count"
-                  },
-                  "required": {
-                    "anyOf": [
-                      {
-                        "type": "boolean"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Required"
-                  },
-                  "values": {
-                    "anyOf": [
-                      {
-                        "items": {
-                          "type": "string"
-                        },
-                        "type": "array"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Values"
-                  },
-                  "manual": {
-                    "anyOf": [
-                      {
-                        "type": "boolean"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Manual"
-                  },
-                  "assignee": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Assignee"
-                  },
-                  "tested_by": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Tested By"
-                  },
-                  "result_id": {
-                    "anyOf": [
-                      {
-                        "type": "integer"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Result Id"
-                  }
-                },
-                "title": "EntitySummary",
-                "type": "object"
+                "$ref": "#/$defs/EntitySummary"
               },
               {
                 "type": "null"
@@ -10933,260 +10482,7 @@
             "anyOf": [
               {
                 "items": {
-                  "additionalProperties": false,
-                  "description": "Closed common vocabulary for collection entries across Lucius tools.",
-                  "properties": {
-                    "id": {
-                      "anyOf": [
-                        {
-                          "type": "integer"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Id"
-                    },
-                    "name": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Name"
-                    },
-                    "key": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Key"
-                    },
-                    "status": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Status"
-                    },
-                    "url": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Url"
-                    },
-                    "type": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Type"
-                    },
-                    "closed": {
-                      "anyOf": [
-                        {
-                          "type": "boolean"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Closed"
-                    },
-                    "tags": {
-                      "anyOf": [
-                        {
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Tags"
-                    },
-                    "project_id": {
-                      "anyOf": [
-                        {
-                          "type": "integer"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Project Id"
-                    },
-                    "test_case_id": {
-                      "anyOf": [
-                        {
-                          "type": "integer"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Test Case Id"
-                    },
-                    "test_layer_id": {
-                      "anyOf": [
-                        {
-                          "type": "integer"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Test Layer Id"
-                    },
-                    "test_layer_name": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Test Layer Name"
-                    },
-                    "steps_count": {
-                      "anyOf": [
-                        {
-                          "minimum": 0,
-                          "type": "integer"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Steps Count"
-                    },
-                    "test_cases_count": {
-                      "anyOf": [
-                        {
-                          "minimum": 0,
-                          "type": "integer"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Test Cases Count"
-                    },
-                    "required": {
-                      "anyOf": [
-                        {
-                          "type": "boolean"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Required"
-                    },
-                    "values": {
-                      "anyOf": [
-                        {
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Values"
-                    },
-                    "manual": {
-                      "anyOf": [
-                        {
-                          "type": "boolean"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Manual"
-                    },
-                    "assignee": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Assignee"
-                    },
-                    "tested_by": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Tested By"
-                    },
-                    "result_id": {
-                      "anyOf": [
-                        {
-                          "type": "integer"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Result Id"
-                    }
-                  },
-                  "title": "EntitySummary",
-                  "type": "object"
+                  "$ref": "#/$defs/SuiteNodeOutput"
                 },
                 "type": "array"
               },
@@ -11195,12 +10491,12 @@
               }
             ],
             "default": null,
-            "description": "Entity-specific collection entries.",
             "title": "Items"
           },
           "total": {
             "anyOf": [
               {
+                "minimum": 0,
                 "type": "integer"
               },
               {
@@ -13344,6 +12640,7 @@
       },
       "outputSchema": {
         "additionalProperties": false,
+        "description": "Confirmation for unlinking an issue by numeric ID or issue key.",
         "properties": {
           "test_case_id": {
             "anyOf": [
@@ -13361,6 +12658,9 @@
             "anyOf": [
               {
                 "type": "integer"
+              },
+              {
+                "type": "string"
               },
               {
                 "type": "null"
@@ -14480,6 +13780,7 @@
       },
       "outputSchema": {
         "additionalProperties": false,
+        "description": "Matcher list for a defect.",
         "properties": {
           "defect_id": {
             "anyOf": [
@@ -14498,7 +13799,7 @@
               {
                 "items": {
                   "additionalProperties": false,
-                  "description": "Closed common vocabulary for collection entries across Lucius tools.",
+                  "description": "A matcher entry returned when listing a defect's automation rules.",
                   "properties": {
                     "id": {
                       "anyOf": [
@@ -14524,7 +13825,7 @@
                       "default": null,
                       "title": "Name"
                     },
-                    "key": {
+                    "message_regex": {
                       "anyOf": [
                         {
                           "type": "string"
@@ -14534,9 +13835,9 @@
                         }
                       ],
                       "default": null,
-                      "title": "Key"
+                      "title": "Message Regex"
                     },
-                    "status": {
+                    "trace_regex": {
                       "anyOf": [
                         {
                           "type": "string"
@@ -14546,210 +13847,10 @@
                         }
                       ],
                       "default": null,
-                      "title": "Status"
-                    },
-                    "url": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Url"
-                    },
-                    "type": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Type"
-                    },
-                    "closed": {
-                      "anyOf": [
-                        {
-                          "type": "boolean"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Closed"
-                    },
-                    "tags": {
-                      "anyOf": [
-                        {
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Tags"
-                    },
-                    "project_id": {
-                      "anyOf": [
-                        {
-                          "type": "integer"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Project Id"
-                    },
-                    "test_case_id": {
-                      "anyOf": [
-                        {
-                          "type": "integer"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Test Case Id"
-                    },
-                    "test_layer_id": {
-                      "anyOf": [
-                        {
-                          "type": "integer"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Test Layer Id"
-                    },
-                    "test_layer_name": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Test Layer Name"
-                    },
-                    "steps_count": {
-                      "anyOf": [
-                        {
-                          "minimum": 0,
-                          "type": "integer"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Steps Count"
-                    },
-                    "test_cases_count": {
-                      "anyOf": [
-                        {
-                          "minimum": 0,
-                          "type": "integer"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Test Cases Count"
-                    },
-                    "required": {
-                      "anyOf": [
-                        {
-                          "type": "boolean"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Required"
-                    },
-                    "values": {
-                      "anyOf": [
-                        {
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Values"
-                    },
-                    "manual": {
-                      "anyOf": [
-                        {
-                          "type": "boolean"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Manual"
-                    },
-                    "assignee": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Assignee"
-                    },
-                    "tested_by": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Tested By"
-                    },
-                    "result_id": {
-                      "anyOf": [
-                        {
-                          "type": "integer"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Result Id"
+                      "title": "Trace Regex"
                     }
                   },
-                  "title": "EntitySummary",
+                  "title": "DefectMatcherSummary",
                   "type": "object"
                 },
                 "type": "array"
@@ -14759,12 +13860,12 @@
               }
             ],
             "default": null,
-            "description": "Entity-specific collection entries.",
             "title": "Items"
           },
           "total": {
             "anyOf": [
               {
+                "minimum": 0,
                 "type": "integer"
               },
               {
@@ -14777,6 +13878,7 @@
           "page": {
             "anyOf": [
               {
+                "minimum": 0,
                 "type": "integer"
               },
               {
@@ -14789,6 +13891,7 @@
           "size": {
             "anyOf": [
               {
+                "minimum": 0,
                 "type": "integer"
               },
               {
@@ -14801,6 +13904,7 @@
           "total_pages": {
             "anyOf": [
               {
+                "minimum": 0,
                 "type": "integer"
               },
               {

--- a/specs/implementation-artifacts/9-14-publish-accurate-mcp-tool-output-schemas.md
+++ b/specs/implementation-artifacts/9-14-publish-accurate-mcp-tool-output-schemas.md
@@ -1,6 +1,6 @@
 # Story 9.14: Publish Accurate MCP Tool Output Schemas
 
-Status: review
+Status: done
 
 ## Story
 
@@ -173,3 +173,21 @@ Codex GPT-5
 ## Change Log
 
 - 2026-07-17: Added validated, per-tool MCP output schemas, regenerated the manifest, and hardened schema/CLI regression coverage.
+- 2026-07-18: Fixed review findings for concrete nested output models, nullable payload preservation, and MCP contract regression coverage.
+
+### Review Findings
+
+- [x] [Review][Patch] Collection item schemas reject normal non-empty payloads [src/tools/output_schemas.py:193]
+  - `items` is always `list[EntitySummary]` with `extra="forbid"`, but `list_launches` emits launch metadata, `list_test_suites` emits recursive `children`, and `list_defect_matchers` emits regex fields. The MCP validation boundary therefore raises a validation error instead of returning these normal responses (AC2, AC4).
+- [x] [Review][Patch] Test-case details reject populated custom-field entries [src/tools/output_schemas.py:174]
+  - The `custom_fields` list accepts `EntitySummary`, while `get_test_case_details` emits `{name, value}` items. `value` is forbidden by that model, so normal structured MCP output fails for test cases with custom fields (AC2, AC4).
+- [x] [Review][Patch] Issue-key unlink responses reject documented string identifiers [src/tools/output_schemas.py:191]
+  - `unlink_issue_from_test_case` accepts and returns an `int | str` issue ID, but the schema accepts only `int`; a documented key such as `PROJ-123` fails MCP output validation (AC2, AC4).
+- [x] [Review][Patch] Launch date fields are typed as strings instead of their emitted integer timestamps [src/tools/output_schemas.py:171]
+  - The generated launch DTO exposes `created_date` and `last_modified_date` as strict integers, while these schema fields are strict strings. Create/get/close/reopen launch responses fail validation whenever those dates are present (AC2, AC4).
+- [x] [Review][Patch] Cleanup tools omit their confirmation response fields [src/tools/cleanup.py:23]
+  - The three cleanup tools declare only `deleted_count` but return `requires_confirmation` and `action` before confirmation. Their default/json MCP confirmation path fails closed-schema validation (AC2, AC4).
+- [x] [Review][Patch] MCP wrapper silently removes nullable response fields [src/utils/telemetry.py:73]
+  - `model_dump(..., exclude_none=True)` changes existing structured payloads by dropping explicitly null keys. Preserve nulls so the published schema and flat MCP contract remain faithful (AC2, AC3, AC6).
+- [x] [Review][Patch] Contract tests do not exercise each tool's actual normal payloads [tests/unit/test_output_schemas.py:30]
+  - Tests fabricate minimal empty/confirmation payloads and only validate one concrete success payload. Add representative success, empty, confirmation, and complex nested branches per registered output model (AC5.3).

--- a/specs/implementation-artifacts/sprint-status.yaml
+++ b/specs/implementation-artifacts/sprint-status.yaml
@@ -34,7 +34,7 @@
 # - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
 
 generated: 2025-12-27 18:46
-last_updated: 2026-07-17
+last_updated: 2026-07-18
 project: lucius-mcp
 project_key: lucius-mcp
 tracking_system: file-system
@@ -138,7 +138,7 @@ development_status:
   9-11-cli-table-human-readable-dates-local-timezone-fallback: done
   9-12-cli-short-entity-aliases: done
   9-13-cli-comprehensive-e2e-coverage-via-uv-run-lucius: done
-  9-14-publish-accurate-mcp-tool-output-schemas: review
+  9-14-publish-accurate-mcp-tool-output-schemas: done
   epic-9-retrospective: optional
 
   # Epic 10: Quality of Life and API Coverage

--- a/src/tools/cleanup.py
+++ b/src/tools/cleanup.py
@@ -20,7 +20,7 @@ from src.tools.output_schemas import output_fields
 DESTRUCTIVE_CONFIRMATION_MESSAGE = "⚠️ Destructive operation. Pass confirm=True to proceed."
 
 
-@output_fields("deleted_count")
+@output_fields("requires_confirmation", "action", "deleted_count")
 async def delete_archived_test_cases(
     confirm: Annotated[bool, Field(description="Must be set to True to proceed.")] = False,
     project_id: Annotated[int | None, Field(description="Optional Allure TestOps project ID override.")] = None,
@@ -52,7 +52,7 @@ async def delete_archived_test_cases(
         )
 
 
-@output_fields("deleted_count")
+@output_fields("requires_confirmation", "action", "deleted_count")
 async def delete_archived_shared_steps(
     confirm: Annotated[bool, Field(description="Must be set to True to proceed.")] = False,
     project_id: Annotated[int | None, Field(description="Optional Allure TestOps project ID override.")] = None,
@@ -84,7 +84,7 @@ async def delete_archived_shared_steps(
         )
 
 
-@output_fields("deleted_count")
+@output_fields("requires_confirmation", "action", "deleted_count")
 async def delete_unused_custom_fields(
     confirm: Annotated[bool, Field(description="Must be set to True to proceed.")] = False,
     project_id: Annotated[int | None, Field(description="Optional Allure TestOps project ID override.")] = None,

--- a/src/tools/defects.py
+++ b/src/tools/defects.py
@@ -15,7 +15,7 @@ from src.tools.output_contract import (
     render_confirmation_required,
     render_output,
 )
-from src.tools.output_schemas import output_fields
+from src.tools.output_schemas import ListDefectMatchersOutput, UnlinkIssueFromTestCaseOutput, output_fields
 from src.utils.links import defect_url, test_case_url
 
 
@@ -398,7 +398,7 @@ async def list_defect_test_cases(
         )
 
 
-@output_fields("test_case_id", "issue_id", "status", "already_unlinked")
+@output_fields("test_case_id", "issue_id", "status", "already_unlinked", model=UnlinkIssueFromTestCaseOutput)
 async def unlink_issue_from_test_case(
     test_case_id: Annotated[int, "ID of the test case to unlink from"],
     issue_id: Annotated[int | str, "Issue key or internal issue-link ID to unlink"],
@@ -588,7 +588,7 @@ async def delete_defect_matcher(
         )
 
 
-@output_fields("defect_id", "items", "total", "page", "size", "total_pages")
+@output_fields("defect_id", "items", "total", "page", "size", "total_pages", model=ListDefectMatchersOutput)
 async def list_defect_matchers(
     defect_id: Annotated[int, "ID of the parent defect"],
     output_format: Annotated[

--- a/src/tools/launches.py
+++ b/src/tools/launches.py
@@ -18,7 +18,7 @@ from src.services.launch_service import (
     ManualTestSubmissionResult,
 )
 from src.tools.output_contract import DEFAULT_OUTPUT_FORMAT, OutputFormat, ToolOutput, render_output
-from src.tools.output_schemas import output_fields
+from src.tools.output_schemas import LaunchSummary, ListLaunchesOutput, output_fields
 from src.utils.auth_resolution import resolve_auth_settings
 from src.utils.links import launch_url
 
@@ -40,7 +40,7 @@ _LAUNCH_OUTPUT_FIELDS = (
 )
 
 
-@output_fields(*_LAUNCH_OUTPUT_FIELDS)
+@output_fields(*_LAUNCH_OUTPUT_FIELDS, model=LaunchSummary)
 async def create_launch(
     name: Annotated[str, Field(description="Launch name (required).")],
     autoclose: Annotated[bool | None, Field(description="Whether the launch auto-closes.")] = None,
@@ -152,7 +152,7 @@ async def upload_test_results(
     )
 
 
-@output_fields(*_COLLECTION_OUTPUT_FIELDS)
+@output_fields(*_COLLECTION_OUTPUT_FIELDS, model=ListLaunchesOutput)
 async def list_launches(
     page: Annotated[int, Field(description="Zero-based page index.")] = 0,
     size: Annotated[int, Field(description="Number of results per page (max 100).", le=100)] = 20,
@@ -207,7 +207,7 @@ async def list_launches(
     )
 
 
-@output_fields(*_LAUNCH_OUTPUT_FIELDS)
+@output_fields(*_LAUNCH_OUTPUT_FIELDS, model=LaunchSummary)
 async def get_launch(
     launch_id: Annotated[int, Field(description="Launch ID (required).")],
     project_id: Annotated[int | None, Field(description="Optional override for the default Project ID.")] = None,
@@ -624,7 +624,7 @@ async def delete_launch(
     )
 
 
-@output_fields(*_LAUNCH_OUTPUT_FIELDS)
+@output_fields(*_LAUNCH_OUTPUT_FIELDS, model=LaunchSummary)
 async def close_launch(
     launch_id: Annotated[int, Field(description="Launch ID (required).")],
     project_id: Annotated[int | None, Field(description="Optional override for the default Project ID.")] = None,
@@ -663,7 +663,7 @@ async def close_launch(
     )
 
 
-@output_fields(*_LAUNCH_OUTPUT_FIELDS)
+@output_fields(*_LAUNCH_OUTPUT_FIELDS, model=LaunchSummary)
 async def reopen_launch(
     launch_id: Annotated[int, Field(description="Launch ID (required).")],
     project_id: Annotated[int | None, Field(description="Optional override for the default Project ID.")] = None,

--- a/src/tools/list_test_suites.py
+++ b/src/tools/list_test_suites.py
@@ -14,7 +14,7 @@ from pydantic import Field
 from src.client import AllureClient
 from src.services.test_hierarchy_service import SuiteNode, TestHierarchyService
 from src.tools.output_contract import DEFAULT_OUTPUT_FORMAT, OutputFormat, ToolOutput, render_output
-from src.tools.output_schemas import output_fields
+from src.tools.output_schemas import ListTestSuitesOutput, output_fields
 
 
 def _format_suite_lines(nodes: list[SuiteNode], indent: int = 0) -> list[str]:
@@ -27,7 +27,7 @@ def _format_suite_lines(nodes: list[SuiteNode], indent: int = 0) -> list[str]:
     return lines
 
 
-@output_fields("tree", "items", "total")
+@output_fields("tree", "items", "total", model=ListTestSuitesOutput)
 async def list_test_suites(
     project_id: Annotated[int | None, Field(description="Allure TestOps project ID.")] = None,
     tree_id: Annotated[

--- a/src/tools/output_schemas.py
+++ b/src/tools/output_schemas.py
@@ -141,6 +141,119 @@ class SearchTestCasesOutput(BaseModel):
     items: list[TestCaseSummary] = Field(description="Matching test cases.")
 
 
+class SuiteNodeOutput(BaseModel):
+    """A recursive hierarchy-suite node."""
+
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    id: int | None = Field(default=None)
+    name: str | None = Field(default=None)
+    children: list[SuiteNodeOutput] = Field(default_factory=list)
+
+
+class LaunchSummary(BaseModel):
+    """The launch fields emitted by the launch list and detail tools."""
+
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    id: int | None = Field(default=None)
+    name: str | None = Field(default=None)
+    closed: bool | None = Field(default=None)
+    created_date: int | None = Field(default=None)
+    last_modified_date: int | None = Field(default=None)
+    project_id: int | None = Field(default=None)
+    autoclose: bool | None = Field(default=None)
+    external: bool | None = Field(default=None)
+    known_defects_count: int | None = Field(default=None, ge=0)
+    new_defects_count: int | None = Field(default=None, ge=0)
+    manual_execution_guidance: str | None = Field(default=None)
+    url: str | None = Field(default=None)
+    operation: str | None = Field(default=None)
+
+
+class ListLaunchesOutput(BaseModel):
+    """Paginated launch summaries."""
+
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    total: int | None = Field(default=None, ge=0)
+    page: int | None = Field(default=None, ge=0)
+    size: int | None = Field(default=None, ge=0)
+    total_pages: int | None = Field(default=None, ge=0)
+    items: list[LaunchSummary] | None = Field(default=None)
+
+
+class ListTestSuitesOutput(BaseModel):
+    """Hierarchy tree and its recursive suite nodes."""
+
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    tree: EntitySummary | None = Field(default=None)
+    items: list[SuiteNodeOutput] | None = Field(default=None)
+    total: int | None = Field(default=None, ge=0)
+
+
+class DefectMatcherSummary(BaseModel):
+    """A matcher entry returned when listing a defect's automation rules."""
+
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    id: int | None = Field(default=None)
+    name: str | None = Field(default=None)
+    message_regex: str | None = Field(default=None)
+    trace_regex: str | None = Field(default=None)
+
+
+class ListDefectMatchersOutput(BaseModel):
+    """Matcher list for a defect."""
+
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    defect_id: int | None = Field(default=None)
+    items: list[DefectMatcherSummary] | None = Field(default=None)
+    total: int | None = Field(default=None, ge=0)
+    page: int | None = Field(default=None, ge=0)
+    size: int | None = Field(default=None, ge=0)
+    total_pages: int | None = Field(default=None, ge=0)
+
+
+class CustomFieldEntry(BaseModel):
+    """A named custom-field value exposed by test-case details."""
+
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    name: str = Field(description="Custom field name.")
+    value: str = Field(description="Rendered custom field value.")
+
+
+class TestCaseDetailsOutput(BaseModel):
+    """Structured details for one test case."""
+
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    id: int | None = Field(default=None)
+    name: str | None = Field(default=None)
+    status: str | None = Field(default=None)
+    description: str | None = Field(default=None)
+    precondition: str | None = Field(default=None)
+    tags: list[str] | None = Field(default=None)
+    custom_fields: list[CustomFieldEntry] | None = Field(default=None)
+    attachments: list[Attachment] | None = Field(default=None)
+    steps: list[Step] | None = Field(default=None)
+    url: str | None = Field(default=None)
+
+
+class UnlinkIssueFromTestCaseOutput(BaseModel):
+    """Confirmation for unlinking an issue by numeric ID or issue key."""
+
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    test_case_id: int | None = Field(default=None)
+    issue_id: int | str | None = Field(default=None)
+    status: str | None = Field(default=None)
+    already_unlinked: bool | None = Field(default=None)
+
+
 class ToolOutputModel(BaseModel):
     """Shared, closed vocabulary used by concrete per-tool response models.
 
@@ -168,10 +281,10 @@ class ToolOutputModel(BaseModel):
     changed: bool | None = Field(default=None)
     changes: list[str] | None = Field(default=None)
     closed: bool | None = Field(default=None)
-    created_date: str | None = Field(default=None)
+    created_date: int | None = Field(default=None)
     custom_field_id: int | None = Field(default=None)
     custom_field_name: str | None = Field(default=None)
-    custom_fields: list[EntitySummary] | dict[str, str | int | float | bool | list[str] | None] | None = Field(
+    custom_fields: list[CustomFieldEntry] | dict[str, str | int | float | bool | list[str] | None] | None = Field(
         default=None, description="Custom-field values as named entries or a value map."
     )
     defect_id: int | None = Field(default=None)
@@ -188,14 +301,14 @@ class ToolOutputModel(BaseModel):
     force_manual: bool | None = Field(default=None)
     id: int | None = Field(default=None)
     integration_id: int | None = Field(default=None)
-    issue_id: int | None = Field(default=None)
+    issue_id: int | str | None = Field(default=None)
     issue_key: str | None = Field(default=None)
     items: list[EntitySummary] | None = Field(default=None, description="Entity-specific collection entries.")
     job_id: int | None = Field(default=None)
     job_run_id: int | None = Field(default=None)
     key: str | None = Field(default=None)
     known_defects_count: int | None = Field(default=None, ge=0)
-    last_modified_date: str | None = Field(default=None)
+    last_modified_date: int | None = Field(default=None)
     launch_id: int | None = Field(default=None)
     layer_id: int | None = Field(default=None)
     manual_execution_guidance: str | None = Field(default=None)

--- a/src/tools/search.py
+++ b/src/tools/search.py
@@ -6,7 +6,7 @@ from src.client import AllureClient, AllureValidationError
 from src.client.generated.models.shared_step_step_dto import SharedStepStepDto
 from src.services.search_service import SearchQueryParser, SearchService, TestCaseDetails, TestCaseListResult
 from src.tools.output_contract import DEFAULT_OUTPUT_FORMAT, OutputFormat, ToolOutput, render_output
-from src.tools.output_schemas import SearchTestCasesOutput, output_fields
+from src.tools.output_schemas import SearchTestCasesOutput, TestCaseDetailsOutput, output_fields
 from src.utils.links import shared_step_url, test_case_url
 
 
@@ -199,6 +199,7 @@ async def search_test_cases(
     "attachments",
     "steps",
     "url",
+    model=TestCaseDetailsOutput,
 )
 async def get_test_case_details(
     test_case_id: Annotated[int, Field(description="ID of the test case to retrieve.")],

--- a/src/utils/telemetry.py
+++ b/src/utils/telemetry.py
@@ -71,7 +71,7 @@ def _apply_mcp_output_contract(result: object, output_model: type[BaseModel]) ->
         return result
 
     payload = output_model.model_validate(result.structured_content).model_dump(
-        mode="json", by_alias=True, exclude_none=True
+        mode="json", by_alias=True, exclude_unset=True
     )
     return ToolResult(
         content=result.content,

--- a/tests/unit/test_output_schemas.py
+++ b/tests/unit/test_output_schemas.py
@@ -1,3 +1,5 @@
+import pytest
+
 from src.tools import all_tools
 from src.tools.output_schemas import OUTPUT_MODELS, output_model_for, output_schema_for, validate_registry_coverage
 
@@ -83,3 +85,89 @@ def test_search_schema_validates_nested_serialized_payload() -> None:
             }
         ],
     }
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "payload"),
+    [
+        (
+            "list_launches",
+            {
+                "total": 1,
+                "page": 0,
+                "size": 20,
+                "total_pages": 1,
+                "items": [
+                    {
+                        "id": 7,
+                        "name": "Nightly",
+                        "closed": False,
+                        "created_date": 1_700_000_000_000,
+                        "last_modified_date": 1_700_000_100_000,
+                        "project_id": 1,
+                        "autoclose": True,
+                        "external": False,
+                        "known_defects_count": 0,
+                        "new_defects_count": 1,
+                        "manual_execution_guidance": "Use manual execution tools.",
+                        "url": "https://example.test/launch/7",
+                    }
+                ],
+            },
+        ),
+        (
+            "list_test_suites",
+            {
+                "tree": {"id": 1, "name": "Default"},
+                "total": 1,
+                "items": [{"id": 2, "name": "Parent", "children": [{"id": 3, "name": "Child", "children": []}]}],
+            },
+        ),
+        (
+            "list_defect_matchers",
+            {
+                "defect_id": 4,
+                "total": 1,
+                "items": [{"id": 5, "name": "Matcher", "message_regex": "boom", "trace_regex": "trace"}],
+            },
+        ),
+        (
+            "get_test_case_details",
+            {
+                "id": 6,
+                "name": "Login",
+                "status": "Active",
+                "tags": [],
+                "custom_fields": [{"name": "Layer", "value": "UI"}],
+                "attachments": [],
+                "steps": [],
+            },
+        ),
+        (
+            "unlink_issue_from_test_case",
+            {"test_case_id": 8, "issue_id": "PROJ-123", "status": "unlinked", "already_unlinked": False},
+        ),
+        (
+            "create_launch",
+            {"id": 9, "name": "Launch", "created_date": 1_700_000_000_000, "closed": False},
+        ),
+        (
+            "delete_archived_test_cases",
+            {"requires_confirmation": True, "action": "delete_archived_test_cases"},
+        ),
+        (
+            "delete_archived_shared_steps",
+            {"requires_confirmation": True, "action": "delete_archived_shared_steps"},
+        ),
+        (
+            "delete_unused_custom_fields",
+            {"requires_confirmation": True, "action": "delete_unused_custom_fields"},
+        ),
+    ],
+)
+def test_specialized_models_accept_documented_normal_payloads(tool_name: str, payload: dict[str, object]) -> None:
+    model = output_model_for(tool_name)
+
+    validated = model.model_validate(payload)
+
+    assert validated.model_dump(mode="json", by_alias=True, exclude_unset=True) == payload

--- a/tests/unit/test_tool_structured_outputs.py
+++ b/tests/unit/test_tool_structured_outputs.py
@@ -2,12 +2,13 @@ from unittest.mock import AsyncMock
 
 import pytest
 from fastmcp.tools import Tool
+from fastmcp.tools.base import ToolResult
 
 import src.tools.search as search_tools
 from src.client import PageTestCaseDto, TestCaseDto
 from src.client.generated.models.test_tag_dto import TestTagDto
 from src.tools.output_schemas import output_model_for, output_schema_for
-from src.utils.telemetry import wrap_tool_with_telemetry
+from src.utils.telemetry import _apply_mcp_output_contract, wrap_tool_with_telemetry
 
 
 class _ClientContext:
@@ -150,3 +151,12 @@ async def test_fastmcp_emits_only_structured_content_when_json_output_is_request
     assert result.structured_content is not None
     assert result.structured_content["items"][0]["tags"] == ["smoke"]
     assert result.structured_content["items"][0]["url"] == "https://example.com/project/123/test-cases/1"
+
+
+def test_mcp_contract_preserves_explicit_null_fields() -> None:
+    result = ToolResult(content=[], structured_content={"id": 1, "name": "Defect", "description": None, "url": "x"})
+
+    validated = _apply_mcp_output_contract(result, output_model_for("create_defect"))
+
+    assert isinstance(validated, ToolResult)
+    assert validated.structured_content == {"id": 1, "name": "Defect", "description": None, "url": "x"}


### PR DESCRIPTION
## Description

Refines MCP tool output contracts with specialized models for launches, suite hierarchies, defect matchers, test-case details, and issue unlinking. The generated manifest now publishes accurate nested shapes and runtime payloads are validated against the tightened schemas.

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] 🧹 Refactoring
- [x] 📝 Documentation
- [ ] 🚀 Release/Deployment
- [x] 🧪 Testing update
- [ ] 🔧 Infrastructure/Configuration

## Related Issues/Stories

- Story 9.14: Publish accurate MCP tool output schemas

## How Has This Been Tested?

- Pre-push hook runs Ruff, mypy, and unit/integration/docs/packaging tests.
- Added parametrized output-schema tests for specialized nested payloads.

## Checklist

- [ ] PR is human-reviewed.
- [x] Documentation has been updated (if applicable).
- [x] Tests have been added or updated to cover changes.