### PR TITLE
chore: prepare release v0.12.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.12.3] - 2026-07-20
+
+### Changed
+- Updated locked Python dependencies, including Cyclopts 4.22.0, Faker 40.31.0, Mypy 2.3.0, Platformdirs 4.10.1, and Ruff 0.15.22 (#299).
+- Updated GitHub Actions dependencies for release and MCPB workflows (#299).
+
 ## [v0.12.2] - 2026-07-18
 
 ### Changed
@@ -296,7 +302,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release
 
-[Unreleased]: https://github.com/ivanostanin/lucius-mcp/compare/v0.12.2...HEAD
+[Unreleased]: https://github.com/ivanostanin/lucius-mcp/compare/v0.12.3...HEAD
+[v0.12.3]: https://github.com/ivanostanin/lucius-mcp/compare/v0.12.2...v0.12.3
 [v0.12.2]: https://github.com/ivanostanin/lucius-mcp/compare/v0.12.1...v0.12.2
 [v0.12.1]: https://github.com/ivanostanin/lucius-mcp/compare/v0.12.0...v0.12.1
 [v0.12.0]: https://github.com/ivanostanin/lucius-mcp/compare/v0.11.0...v0.12.0

--- a/docs/mcp_manifest.json
+++ b/docs/mcp_manifest.json
@@ -6,7 +6,7 @@
   "serverInfo": {
     "name": "lucius-mcp",
     "title": null,
-    "version": "0.12.2",
+    "version": "0.12.3",
     "websiteUrl": null,
     "icons": null
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lucius-mcp"
-version = "0.12.2"
+version = "0.12.3"
 description = "Allure TestOps MCP Server"
 readme = "README.md"
 license = "Apache-2.0"

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/ivanostanin/lucius-mcp",
     "source": "github"
   },
-  "version": "0.12.2",
+  "version": "0.12.3",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "lucius-mcp",
-      "version": "0.12.2",
+      "version": "0.12.3",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"
@@ -43,7 +43,7 @@
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/ivanostanin/lucius-mcp:0.12.2",
+      "identifier": "ghcr.io/ivanostanin/lucius-mcp:0.12.3",
       "transport": {
         "type": "stdio"
       },
@@ -73,16 +73,16 @@
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/ivanostanin/lucius-mcp/releases/download/v0.12.2/lucius-mcp-0.12.2-uv.mcpb",
-      "fileSha256": "813228945848e83470a28a33d01975761daf622d814f3aa4c0bdb1051ba71cb9",
+      "identifier": "https://github.com/ivanostanin/lucius-mcp/releases/download/v0.12.3/lucius-mcp-0.12.3-uv.mcpb",
+      "fileSha256": "d04b822eda9dbf2b737db6f8ebd5bab513f1cb3712209d5cf8a05a2418db5814",
       "transport": {
         "type": "stdio"
       }
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/ivanostanin/lucius-mcp/releases/download/v0.12.2/lucius-mcp-0.12.2-python.mcpb",
-      "fileSha256": "838a6cf7b536f9aba879f0d6100955a393c70c3d2474d6e7a64d2f8d283ebecd",
+      "identifier": "https://github.com/ivanostanin/lucius-mcp/releases/download/v0.12.3/lucius-mcp-0.12.3-python.mcpb",
+      "fileSha256": "ddaf3ef5797b56714221083bacc347075b593368ccf0b411a853495a4c51f078",
       "transport": {
         "type": "stdio"
       }

--- a/uv.lock
+++ b/uv.lock
@@ -916,7 +916,7 @@ wheels = [
 
 [[package]]
 name = "lucius-mcp"
-version = "0.12.2"
+version = "0.12.3"
 source = { editable = "." }
 dependencies = [
     { name = "authlib" },


### PR DESCRIPTION
Prepare release v0.12.3.

Includes the consolidated Dependabot updates from #299, changelog entry, MCP manifest, MCPB bundles metadata, and package version bump.

Local validation: full unit/integration/docs/E2E/packaging checks passed; E2E tests requiring live TestOps credentials were skipped.