### PR TITLE
chore: prepare release v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.13.0] - 2026-07-21
+
+### Added
+- Added `get_project` to discover accessible projects and resolve project IDs by name (#301).
+- Added `generate_test_code` to create framework-specific automation snippets from TestOps test cases (#302).
+
 ## [v0.12.3] - 2026-07-20
 
 ### Changed
@@ -302,7 +308,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release
 
-[Unreleased]: https://github.com/ivanostanin/lucius-mcp/compare/v0.12.3...HEAD
+[Unreleased]: https://github.com/ivanostanin/lucius-mcp/compare/v0.13.0...HEAD
+[v0.13.0]: https://github.com/ivanostanin/lucius-mcp/compare/v0.12.3...v0.13.0
 [v0.12.3]: https://github.com/ivanostanin/lucius-mcp/compare/v0.12.2...v0.12.3
 [v0.12.2]: https://github.com/ivanostanin/lucius-mcp/compare/v0.12.1...v0.12.2
 [v0.12.1]: https://github.com/ivanostanin/lucius-mcp/compare/v0.12.0...v0.12.1

--- a/docs/mcp_manifest.json
+++ b/docs/mcp_manifest.json
@@ -6,7 +6,7 @@
   "serverInfo": {
     "name": "lucius-mcp",
     "title": null,
-    "version": "0.12.3",
+    "version": "0.13.0",
     "websiteUrl": null,
     "icons": null
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lucius-mcp"
-version = "0.12.3"
+version = "0.13.0"
 description = "Allure TestOps MCP Server"
 readme = "README.md"
 license = "Apache-2.0"

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/ivanostanin/lucius-mcp",
     "source": "github"
   },
-  "version": "0.12.3",
+  "version": "0.13.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "lucius-mcp",
-      "version": "0.12.3",
+      "version": "0.13.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"
@@ -43,7 +43,7 @@
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/ivanostanin/lucius-mcp:0.12.3",
+      "identifier": "ghcr.io/ivanostanin/lucius-mcp:0.13.0",
       "transport": {
         "type": "stdio"
       },
@@ -73,16 +73,16 @@
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/ivanostanin/lucius-mcp/releases/download/v0.12.3/lucius-mcp-0.12.3-uv.mcpb",
-      "fileSha256": "d04b822eda9dbf2b737db6f8ebd5bab513f1cb3712209d5cf8a05a2418db5814",
+      "identifier": "https://github.com/ivanostanin/lucius-mcp/releases/download/v0.13.0/lucius-mcp-0.13.0-uv.mcpb",
+      "fileSha256": "ffad24c198d8786740f7e6a9f10ac1892fd05378b08b566e9041a7c60f7da9a9",
       "transport": {
         "type": "stdio"
       }
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/ivanostanin/lucius-mcp/releases/download/v0.12.3/lucius-mcp-0.12.3-python.mcpb",
-      "fileSha256": "ddaf3ef5797b56714221083bacc347075b593368ccf0b411a853495a4c51f078",
+      "identifier": "https://github.com/ivanostanin/lucius-mcp/releases/download/v0.13.0/lucius-mcp-0.13.0-python.mcpb",
+      "fileSha256": "2403d485fce8576946baa3c131637dba2c544eac8a6432eae4b8728b60f3c66f",
       "transport": {
         "type": "stdio"
       }

--- a/uv.lock
+++ b/uv.lock
@@ -374,7 +374,7 @@ resolution-markers = [
     "(python_full_version < '3.14' and platform_machine == 'ARM64' and sys_platform == 'win32') or (python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'win32')",
 ]
 dependencies = [
-    { name = "cffi", marker = "(platform_machine == 'ARM64' and platform_python_implementation != 'PyPy' and sys_platform == 'win32') or (platform_machine == 'aarch64' and platform_python_implementation != 'PyPy' and sys_platform == 'win32')" },
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9f/33/c00162f49c0e2fe8064a62cb92b93e50c74a72bc370ab92f86112b33ff62/cryptography-46.0.3.tar.gz", hash = "sha256:a8b17438104fed022ce745b362294d9ce35b4c2e45c1d958ad4a4b019285f4a1", size = 749258, upload-time = "2025-10-15T23:18:31.74Z" }
 wheels = [
@@ -395,7 +395,7 @@ resolution-markers = [
     "python_full_version < '3.14' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "cffi", marker = "(platform_machine != 'ARM64' and platform_machine != 'aarch64' and platform_python_implementation != 'PyPy') or (platform_python_implementation != 'PyPy' and sys_platform != 'win32')" },
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/12/45/870e7f4bef50e5f53b9f51d4428aee5290eedf58ba443f16b1ebb7ab8e66/cryptography-48.0.1.tar.gz", hash = "sha256:266f4ee051abb2f725b74ef8072b521ce1feacf685a3364fa6a6b45548db791a", size = 832989, upload-time = "2026-06-09T22:32:31.8Z" }
 wheels = [
@@ -916,7 +916,7 @@ wheels = [
 
 [[package]]
 name = "lucius-mcp"
-version = "0.12.3"
+version = "0.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "authlib" },
@@ -1776,8 +1776,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", version = "48.0.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.15' and platform_machine != 'ARM64' and platform_machine != 'aarch64') or sys_platform != 'win32'" },
-    { name = "jeepney", marker = "(python_full_version >= '3.15' and platform_machine != 'ARM64' and platform_machine != 'aarch64') or sys_platform != 'win32'" },
+    { name = "cryptography", version = "48.0.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "jeepney" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
## Description

Prepare release v0.13.0 with the new project discovery and test-code generation tools, refreshed versioned manifests, and registry metadata generated from local MCPB artifacts.

## Type of Change

- [ ] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] 🧹 Refactoring
- [ ] 📝 Documentation
- [x] 🚀 Release/Deployment
- [ ] 🧪 Testing update
- [ ] 🔧 Infrastructure/Configuration

## Related Issues/Stories

- #301
- #302

## How Has This Been Tested?

- ./scripts/full-test-suite.sh — formatting, lint, mypy, 975 unit/integration tests, 23 documentation tests, 226 E2E tests with 1 environment-dependent skip, and 41 packaging tests.
- uv run --locked pytest focused release manifest, registry, MCPB, and metadata tests — 26 passed.

## Checklist

- [ ] PR is human-reviewed.
- [x] Documentation has been updated (if applicable).
- [ ] Tests have been added or updated to cover changes.