### PR TITLE
chore: prepare release v0.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.13.1] - 2026-07-21
+
+### Added
+- Added configurable language, framework, and metadata synchronization selections to `generate_test_code`, with compatibility validation and backward-compatible aliases (#305).
+
 ## [v0.13.0] - 2026-07-21
 
 ### Added
@@ -308,7 +313,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release
 
-[Unreleased]: https://github.com/ivanostanin/lucius-mcp/compare/v0.13.0...HEAD
+[Unreleased]: https://github.com/ivanostanin/lucius-mcp/compare/v0.13.1...HEAD
+[v0.13.1]: https://github.com/ivanostanin/lucius-mcp/compare/v0.13.0...v0.13.1
 [v0.13.0]: https://github.com/ivanostanin/lucius-mcp/compare/v0.12.3...v0.13.0
 [v0.12.3]: https://github.com/ivanostanin/lucius-mcp/compare/v0.12.2...v0.12.3
 [v0.12.2]: https://github.com/ivanostanin/lucius-mcp/compare/v0.12.1...v0.12.2

--- a/docs/mcp_manifest.json
+++ b/docs/mcp_manifest.json
@@ -6,7 +6,7 @@
   "serverInfo": {
     "name": "lucius-mcp",
     "title": null,
-    "version": "0.13.0",
+    "version": "0.13.1",
     "websiteUrl": null,
     "icons": null
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lucius-mcp"
-version = "0.13.0"
+version = "0.13.1"
 description = "Allure TestOps MCP Server"
 readme = "README.md"
 license = "Apache-2.0"

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/ivanostanin/lucius-mcp",
     "source": "github"
   },
-  "version": "0.13.0",
+  "version": "0.13.1",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "lucius-mcp",
-      "version": "0.13.0",
+      "version": "0.13.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"
@@ -43,7 +43,7 @@
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/ivanostanin/lucius-mcp:0.13.0",
+      "identifier": "ghcr.io/ivanostanin/lucius-mcp:0.13.1",
       "transport": {
         "type": "stdio"
       },
@@ -73,16 +73,16 @@
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/ivanostanin/lucius-mcp/releases/download/v0.13.0/lucius-mcp-0.13.0-uv.mcpb",
-      "fileSha256": "ffad24c198d8786740f7e6a9f10ac1892fd05378b08b566e9041a7c60f7da9a9",
+      "identifier": "https://github.com/ivanostanin/lucius-mcp/releases/download/v0.13.1/lucius-mcp-0.13.1-uv.mcpb",
+      "fileSha256": "254a609b62655f6e7dc73c029fe32e968783d0761fa7d295c50d5c9860fc9d51",
       "transport": {
         "type": "stdio"
       }
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/ivanostanin/lucius-mcp/releases/download/v0.13.0/lucius-mcp-0.13.0-python.mcpb",
-      "fileSha256": "2403d485fce8576946baa3c131637dba2c544eac8a6432eae4b8728b60f3c66f",
+      "identifier": "https://github.com/ivanostanin/lucius-mcp/releases/download/v0.13.1/lucius-mcp-0.13.1-python.mcpb",
+      "fileSha256": "950d618f51727b7d0a265c9808c76d81fa7117ae50a6c77ec7fb93ad9ce0cc8b",
       "transport": {
         "type": "stdio"
       }

--- a/uv.lock
+++ b/uv.lock
@@ -916,7 +916,7 @@ wheels = [
 
 [[package]]
 name = "lucius-mcp"
-version = "0.13.0"
+version = "0.13.1"
 source = { editable = "." }
 dependencies = [
     { name = "authlib" },


### PR DESCRIPTION
Prepare release v0.13.1.\n\n- Bump package and registry metadata to 0.13.1.\n- Add changelog notes for code generation selection options (#305).\n- Regenerate the MCP manifest and MCPB hashes.