### PR TITLE
fix: order None last in launch status unions

### DIFF
--- a/src/services/launch_service.py
+++ b/src/services/launch_service.py
@@ -555,7 +555,7 @@ class LaunchService:
         launch_id: int,
         *,
         test_case_id: int,
-        status: str | None | Literal["any"] = "any",
+        status: str | Literal["any"] | None = "any",
     ) -> LaunchTestResultListItem:
         """Resolve one visible manual launch result for a specific test case."""
         self._validate_project_id(self._project_id)
@@ -1207,7 +1207,7 @@ class LaunchService:
         )
 
     @staticmethod
-    def _normalize_launch_result_status_filter(status: str | None | Literal["any"]) -> str | None | Literal["any"]:
+    def _normalize_launch_result_status_filter(status: str | Literal["any"] | None) -> str | Literal["any"] | None:
         if status == "any":
             return "any"
         if status is None:


### PR DESCRIPTION
## Description

Orders `None` as the final member of launch-status filter union annotations, resolving Ruff RUF036 violations.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Refactoring
- [ ] 📝 Documentation
- [ ] 🚀 Release/Deployment
- [ ] 🧪 Testing update
- [ ] 🔧 Infrastructure/Configuration

## Related Issues/Stories

None.

## How Has This Been Tested?

- `uv run ruff format --check .`
- `uv run ruff check .`

## Checklist

- [x] PR is human-reviewed.
- [x] Documentation has been updated (if applicable).
- [ ] Tests have been added or updated to cover changes.